### PR TITLE
Fixrequirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ python_requires = >=3.10
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
 install_requires =
-    ibis-framework==10.0.0.dev97
+    ibis-framework[bigquery,duckdb]==10.0.0.dev97
     importlib-metadata; python_version<"3.10"
     ibis-framework[bigquery]
     ibis-framework[duckdb]

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,8 +50,6 @@ python_requires = >=3.10
 install_requires =
     ibis-framework[bigquery,duckdb]==10.0.0.dev97
     importlib-metadata; python_version<"3.10"
-    ibis-framework[bigquery]
-    ibis-framework[duckdb]
     pytest
     omegaconf
     pytz


### PR DESCRIPTION
Closes #22. Specifying all dependencies across multiple lines breaks older versions of pip