### PR TITLE
(bug): Party link table referential integrity failed to validate where there were multiple parties on the link table: RI011

### DIFF
--- a/src/amlaidatatests/tests/test_transaction_table.py
+++ b/src/amlaidatatests/tests/test_transaction_table.py
@@ -74,6 +74,7 @@ def test_RI011_temporal_referential_integrity_account_party_link(connection, req
         to_table_config=to_table_config,
         key="account_id",
         test_id="RI011",
+        validate_datetime_column="book_time",
     )
     test(connection, request)
 


### PR DESCRIPTION
Cases where the account_party_link table has multiple linked parties but one is deleted causes the RI011 to incorrectly
fail:

| party_id | account_id | validity_start_time | is_entity_deleted |
|--------|--------|--------|--------|
| 1 | 0 | 2020-01-01T00:00:00 | False |
| 2 | 0 | 2020-01-01T00:00:00 | False |
| 1 | 0 | 2020-01-01T00:00:00 | True  |

