### PR TITLE
(bug): key concatenation causes overlapping id keys

### DIFF
--- a/src/amlaidatatests/tests/common.py
+++ b/src/amlaidatatests/tests/common.py
@@ -435,9 +435,10 @@ class VerifyTypedValuePresence(AbstractColumnTest):
         where_group_kwargs = {"where": self.where(_)} if self.where else {}
 
         expr = (
-            # Concatenate the group by so we can count unique combinations
+            # Concatenate the group by so we can count unique combinations. We append
+            # column IDs because there might be overlapping individual IDs
             table.mutate(
-                concat=reduce(lambda x, y: x + y, [_[i] for i in self.group_by], "")
+                concat=reduce(lambda x, y: x + y, [i + _[i] for i in self.group_by], "")
             )
             .agg(
                 value_cnt=_["concat"].nunique(column == self.value),


### PR DESCRIPTION
In VerifyTypedValuePresence We use a compound key by appending IDs to count the occurrences over a group. It may fail if the IDs overlap and produce incorrect results, e.g.

| party_id | risk_case_event_id |
|--------|--------|
| 10 | 01 |
| 100 | 1 | 

will result in a single group for both rows:
```
1001
1001
```

To fix this, we append also append the column IDs:
```
party_id10risk_case_event_id01
party_id100risk_case_event_id1
```