### PR TITLE
(feat) Missing tests for validating that all AML_SAR and AML_EXIT events have an AML_PROCESS_START

### DIFF
--- a/src/amlaidatatests/resources/test_descriptions_en_us.csv
+++ b/src/amlaidatatests/resources/test_descriptions_en_us.csv
@@ -51,6 +51,8 @@ P045,RiskCaseEvent,type,<=1 AML_PROCESS_START per risk_case_id and party_id
 P046,RiskCaseEvent,type,<=1 AML_PROCESS_END per risk_case_id and party_id
 P047,RiskCaseEvent,type,<=1 AML_EXIT per risk_case_id and party_id
 P048,RiskCaseEvent,type,All AML_EXIT events have AML_PROCESS_START for same risk_case_id and party_id
+P068,RiskCaseEvent,type,All AML_SAR events have AML_PROCESS_START for same risk_case_id and party_id
+P067,RiskCaseEvent,type,All AML_SAR and AML_EXIT events have AML_PROCESS_START for same risk_case_id and party_id
 P053,RiskCaseEvent,risk_case_event_id,Number of risk case events within risk case
 P054,RiskCaseEvent,risk_case_event_id,Number of risk case events within risk case
 P055,RiskCaseEvent,risk_case_event_id,Number of risk case events for party

--- a/src/amlaidatatests/tests/test_risk_case_event_table.py
+++ b/src/amlaidatatests/tests/test_risk_case_event_table.py
@@ -345,9 +345,10 @@ class NoTransactionsWithinSuspiciousPeriod(AbstractTableTest):
             test_id="P044",
             value="AML_EXIT",
         ),
-        # TODO: This is not a precise test. We are comparing the number
-        # of values of party_id, risk_case_id which have an AML_PROCESS_START over
-        # the number which have an AML_EXIT. This could be a co-incidence
+        # TODO: This is not a precise test. We are comparing the number of
+        # values of party_id, risk_case_id which have an AML_PROCESS_START over
+        # the number which have an AML_EXIT. This could be a co-incidence, so we
+        # test this in a few different ways
         common.VerifyTypedValuePresence(
             column="type",
             table_config=TABLE_CONFIG,
@@ -356,6 +357,27 @@ class NoTransactionsWithinSuspiciousPeriod(AbstractTableTest):
             compare_group_by_where=lambda t: t.type == "AML_EXIT",
             test_id="P048",
             value="AML_PROCESS_START",
+        ),
+        common.VerifyTypedValuePresence(
+            column="type",
+            table_config=TABLE_CONFIG,
+            min_proportion=1,
+            group_by=["party_id", "risk_case_id"],
+            compare_group_by_where=lambda t: t.type == "AML_SAR",
+            test_id="P068",
+            value="AML_PROCESS_START",
+        ),
+        common.VerifyTypedValuePresence(
+            column="type",
+            table_config=TABLE_CONFIG,
+            min_proportion=1,
+            group_by=["party_id", "risk_case_id"],
+            compare_group_by_where=lambda t: (t.type == "AML_SAR")
+            | (t.type == "AML_EXIT"),
+            test_id="P067",
+            value="AML_PROCESS_START",
+            # This errors in the API
+            severity=AMLAITestSeverity.ERROR,
         ),
         common.CountFrequencyValues(
             column="type",

--- a/tests/tests/test_verify_typed_value_presence.py
+++ b/tests/tests/test_verify_typed_value_presence.py
@@ -235,6 +235,243 @@ def test_collar_proportion_group_by_where(test_connection, create_test_table, re
     t(test_connection, request)
 
 
+import ibis
+import pytest
+from ibis.expr.datatypes import String
+
+from amlaidatatests.exceptions import AMLAITestSeverity, DataTestFailure
+from amlaidatatests.schema.base import ResolvedTableConfig, TableType
+from amlaidatatests.tests import common
+
+
+def test_max_proportion_group_by(test_connection, create_test_table, request):
+    schema = {"account_id": String(nullable=False), "column": String(nullable=False)}
+
+    tbl = create_test_table(
+        ibis.memtable(
+            data=[
+                {"account_id": "1", "column": "born"},
+                {"account_id": "2", "column": "married"},
+                {"account_id": "3", "column": "married"},
+            ],
+            schema=schema,
+        )
+    )
+    table_config = ResolvedTableConfig(
+        name=tbl, table=ibis.table(name=tbl, schema=schema), table_type=TableType.EVENT
+    )
+
+    # Check not all account_id have a value of married
+    t = common.VerifyTypedValuePresence(
+        table_config=table_config,
+        group_by=["account_id"],
+        max_proportion=1,
+        column="column",
+        value="married",
+    )
+    t(test_connection, request)  # should succeed
+
+
+def test_max_proportion_group_by_fails(test_connection, create_test_table, request):
+    schema = {"account_id": String(nullable=False), "column": String(nullable=False)}
+
+    tbl = create_test_table(
+        ibis.memtable(
+            data=[
+                {"account_id": "1", "column": "married"},
+                {"account_id": "1", "column": "born"},
+                {"account_id": "2", "column": "married"},
+                {"account_id": "3", "column": "married"},
+            ],
+            schema=schema,
+        )
+    )
+    table_config = ResolvedTableConfig(
+        name=tbl, table=ibis.table(name=tbl, schema=schema), table_type=TableType.EVENT
+    )
+
+    # Checks not all account_id have a value of married
+    t = common.VerifyTypedValuePresence(
+        table_config=table_config,
+        group_by=["account_id"],
+        max_proportion=1,
+        column="column",
+        value="married",
+        severity=AMLAITestSeverity.ERROR,
+    )
+    with pytest.raises(DataTestFailure):
+        t(test_connection, request)
+
+
+def test_collar_proportion_group_by_fails_too_high(
+    test_connection, create_test_table, request
+):
+    schema = {
+        "transaction_id": String(nullable=False),
+        "direction": String(nullable=False),
+    }
+
+    tbl = create_test_table(
+        ibis.memtable(
+            data=[
+                {"transaction_id": "1", "direction": "DEBIT"},
+                {"transaction_id": "2", "direction": "DEBIT"},
+                {"transaction_id": "3", "direction": "DEBIT"},
+                {"transaction_id": "4", "direction": "DEBIT"},
+                {"transaction_id": "5", "direction": "DEBIT"},
+                {"transaction_id": "6", "direction": "DEBIT"},
+                {"transaction_id": "7", "direction": "DEBIT"},
+                {"transaction_id": "8", "direction": "CREDIT"},
+                {"transaction_id": "9", "direction": "CREDIT"},
+                {"transaction_id": "10", "direction": "CREDIT"},
+            ],
+            schema=schema,
+        )
+    )
+    TABLE_CONFIG = ResolvedTableConfig(
+        name=tbl, table=ibis.table(name=tbl, schema=schema), table_type=TableType.EVENT
+    )
+
+    # Checks not all account_id have a value of married
+    t = common.VerifyTypedValuePresence(
+        column="direction",
+        table_config=TABLE_CONFIG,
+        min_proportion=0.4,
+        max_proportion=0.6,
+        group_by=["transaction_id"],
+        severity=AMLAITestSeverity.ERROR,
+        value="DEBIT",
+    )
+    with pytest.raises(DataTestFailure):
+        t(test_connection, request)
+
+
+def test_collar_proportion_group_by_fails_too_low(
+    test_connection, create_test_table, request
+):
+    schema = {
+        "transaction_id": String(nullable=False),
+        "direction": String(nullable=False),
+    }
+
+    tbl = create_test_table(
+        ibis.memtable(
+            data=[
+                {"transaction_id": "1", "direction": "DEBIT"},
+                {"transaction_id": "2", "direction": "DEBIT"},
+                {"transaction_id": "3", "direction": "DEBIT"},
+                {"transaction_id": "4", "direction": "DEBIT"},
+                {"transaction_id": "5", "direction": "DEBIT"},
+                {"transaction_id": "6", "direction": "DEBIT"},
+                {"transaction_id": "7", "direction": "DEBIT"},
+                {"transaction_id": "8", "direction": "CREDIT"},
+                {"transaction_id": "9", "direction": "CREDIT"},
+                {"transaction_id": "10", "direction": "CREDIT"},
+            ],
+            schema=schema,
+        )
+    )
+    TABLE_CONFIG = ResolvedTableConfig(
+        name=tbl, table=ibis.table(name=tbl, schema=schema), table_type=TableType.EVENT
+    )
+
+    # Checks not all account_id have a value of married
+    t = common.VerifyTypedValuePresence(
+        column="direction",
+        table_config=TABLE_CONFIG,
+        min_proportion=0.4,
+        max_proportion=0.6,
+        group_by=["transaction_id"],
+        severity=AMLAITestSeverity.ERROR,
+        value="CREDIT",
+    )
+    with pytest.raises(DataTestFailure):
+        t(test_connection, request)
+
+
+def test_collar_proportion_group_by(test_connection, create_test_table, request):
+    schema = {
+        "transaction_id": String(nullable=False),
+        "direction": String(nullable=False),
+    }
+
+    tbl = create_test_table(
+        ibis.memtable(
+            data=[
+                {"transaction_id": "internal_account_1", "direction": "DEBIT"},
+                {"transaction_id": "internal_account_1", "direction": "DEBIT"},
+                {"transaction_id": "internal_account_1", "direction": "DEBIT"},
+                {"transaction_id": "internal_account_1", "direction": "DEBIT"},
+                {"transaction_id": "5", "direction": "DEBIT"},
+                {"transaction_id": "6", "direction": "DEBIT"},
+                {"transaction_id": "7", "direction": "DEBIT"},
+                {"transaction_id": "8", "direction": "CREDIT"},
+                {"transaction_id": "9", "direction": "CREDIT"},
+                {"transaction_id": "10", "direction": "CREDIT"},
+            ],
+            schema=schema,
+        )
+    )
+    TABLE_CONFIG = ResolvedTableConfig(
+        name=tbl, table=ibis.table(name=tbl, schema=schema), table_type=TableType.EVENT
+    )
+
+    # Checks not all account_id have a value of married
+    t = common.VerifyTypedValuePresence(
+        column="direction",
+        table_config=TABLE_CONFIG,
+        min_proportion=0.4,
+        max_proportion=0.6,
+        group_by=["transaction_id"],
+        severity=AMLAITestSeverity.ERROR,
+        value="CREDIT",
+    )
+    t(test_connection, request)
+
+
+def test_collar_proportion_group_by_where(test_connection, create_test_table, request):
+    schema = {
+        "transaction_id": String(nullable=False),
+        "direction": String(nullable=False),
+    }
+
+    tbl = create_test_table(
+        ibis.memtable(
+            data=[
+                {"transaction_id": "internal_account_1", "direction": "DEBIT"},
+                {"transaction_id": "internal_account_2", "direction": "DEBIT"},
+                {"transaction_id": "internal_account_3", "direction": "DEBIT"},
+                {"transaction_id": "internal_account_4", "direction": "DEBIT"},
+                {"transaction_id": "5", "direction": "DEBIT"},
+                {"transaction_id": "6", "direction": "DEBIT"},
+                {"transaction_id": "7", "direction": "DEBIT"},
+                {"transaction_id": "8", "direction": "CREDIT"},
+                {"transaction_id": "9", "direction": "CREDIT"},
+                {"transaction_id": "10", "direction": "CREDIT"},
+            ],
+            schema=schema,
+        )
+    )
+    TABLE_CONFIG = ResolvedTableConfig(
+        name=tbl, table=ibis.table(name=tbl, schema=schema), table_type=TableType.EVENT
+    )
+
+    # Checks not all account_id have a value of married
+    t = common.VerifyTypedValuePresence(
+        column="direction",
+        table_config=TABLE_CONFIG,
+        min_proportion=0.4,
+        max_proportion=0.6,
+        group_by=["transaction_id"],
+        compare_group_by_where=lambda t: t["transaction_id"]
+        .like("%internal_account%")
+        .negate(),
+        severity=AMLAITestSeverity.ERROR,
+        value="CREDIT",
+    )
+    t(test_connection, request)
+
+
 def test_overlapping_value_keys(test_connection, create_test_table, request):
     # See https://github.com/ground-truth-ai/amlaidatatests/pull/38. Some
     # datatests were failing because there was an edge case where certain group
@@ -271,3 +508,42 @@ def test_overlapping_value_keys(test_connection, create_test_table, request):
     )
 
     t(test_connection, request)
+
+
+def test_proportion_counts_fails(test_connection, create_test_table, request):
+    schema = {
+        "party_id": String(nullable=False),
+        "risk_case_id": String(nullable=False),
+        "type": String(nullable=False),
+    }
+
+    tbl = create_test_table(
+        ibis.memtable(
+            data=[
+                {"party_id": "1", "risk_case_id": "1", "type": "AML_PROCESS_START"},
+                {"party_id": "1", "risk_case_id": "1", "type": "OTHER_EVENT"},
+                {"party_id": "1", "risk_case_id": "1", "type": "OTHER_EVENT"},
+                {"party_id": "1", "risk_case_id": "1", "type": "OTHER_EVENT"},
+                {"party_id": "1", "risk_case_id": "1", "type": "OTHER_EVENT"},
+                {"party_id": "1", "risk_case_id": "1", "type": "AML_SAR"},
+                {"party_id": "2", "risk_case_id": "2", "type": "OTHER_EVENT"},
+                {"party_id": "2", "risk_case_id": "2", "type": "AML_SAR"},
+            ],
+            schema=schema,
+        )
+    )
+    TABLE_CONFIG = ResolvedTableConfig(
+        name=tbl, table=ibis.table(name=tbl, schema=schema), table_type=TableType.EVENT
+    )
+
+    t = common.VerifyTypedValuePresence(
+        column="type",
+        table_config=TABLE_CONFIG,
+        min_proportion=1,
+        group_by=["party_id", "risk_case_id"],
+        compare_group_by_where=lambda t: t.type == "AML_SAR",
+        value="AML_PROCESS_START",
+        severity=AMLAITestSeverity.ERROR,
+    )
+    with pytest.raises(DataTestFailure):
+        t(test_connection, request)


### PR DESCRIPTION
AML AI fails when AML_SAR and AML_EXIT events have no AML_PROCESS_START date for the same party_id and risk_case_id.

We need tests which also look for this.

```
{
        "@type": "[type.googleapis.com/google.rpc.ErrorInfo](http://type.googleapis.com/google.rpc.ErrorInfo)",
        "reason": "NO_AML_PROCESS_START_FOR_RISK_CASE",
        "domain": "[financialservices.googleapis.com](http://financialservices.googleapis.com/)",
        "metadata": {
          "data_field": "party_id, risk_case_id",
          "test": "(party_id, risk_case_id COUNTIF(type = \"AML_PROCESS_START\") = 0) WHEN party_id, risk_case_id COUNTIF(type = \"AML_EXIT\" OR \"AML_SAR\" ) = 1)",
          "count": "57",
          "description": "One or multiple positive risk cases that resulted in an exit or SAR don't include AML PROCESS START event. ",
          "data_table": "risk_case_event"
        }
```