### PR TITLE
(bug) Fixes #37. Occupation column should be checked when null for type=COMPANY

### DIFF
--- a/src/amlaidatatests/tests/test_party_table.py
+++ b/src/amlaidatatests/tests/test_party_table.py
@@ -173,7 +173,7 @@ def test_column_values(connection, test, request):
         common.NullIfTest(
             column="occupation",
             table_config=TABLE_CONFIG,
-            expression=lambda t: t.type == "CONSUMER",
+            expression=lambda t: t.type == "COMPANY",
             test_id="V010",
         ),
     ],


### PR DESCRIPTION
It currently checks for CONSUMER.