### PR TITLE
(feat): Support ibis9x formally

### DIFF
--- a/src/amlaidatatests/tests/common.py
+++ b/src/amlaidatatests/tests/common.py
@@ -1315,7 +1315,7 @@ class TemporalReferentialIntegrityTest(AbstractTableTest):
                     first_date=_.validity_start_time.min(),
                     last_date=ibis.ifelse(
                         condition=_.next_row_validity_start_time.isnull()
-                        & _.is_entity_deleted.negate(),
+                        & ~_.is_entity_deleted,
                         true_expr=TemporalReferentialIntegrityTest.MAX_DATETIME_VALUE,
                         false_expr=_.validity_start_time,
                     ).max(),
@@ -1421,16 +1421,16 @@ class TemporalReferentialIntegrityTest(AbstractTableTest):
                     (tbl[self.key] == totbl[self.key])
                     # If this item is before the first date on the base table
                     & (
-                        tbl.first_date.between(
+                        ~tbl.first_date.between(
                             lower=first_date_with_tolerance,
                             upper=last_date_with_tolerance,
-                        ).negate()
+                        )
                         |
                         # If this item is after the last date on the base table
-                        tbl.last_date.between(
+                        ~tbl.last_date.between(
                             lower=first_date_with_tolerance,
                             upper=last_date_with_tolerance,
-                        ).negate()
+                        )
                     )
                 ),
             )

--- a/tests/tests/test_verify_typed_value_presence.py
+++ b/tests/tests/test_verify_typed_value_presence.py
@@ -226,9 +226,9 @@ def test_collar_proportion_group_by_where(test_connection, create_test_table, re
         min_proportion=0.4,
         max_proportion=0.6,
         group_by=["transaction_id"],
-        compare_group_by_where=lambda t: t["transaction_id"]
-        .like("%internal_account%")
-        .negate(),
+        compare_group_by_where=lambda t: ~t["transaction_id"].like(
+            "%internal_account%"
+        ),
         severity=AMLAITestSeverity.ERROR,
         value="CREDIT",
     )


### PR DESCRIPTION
To properly support ibis 9x, we need to:

- Update dependencies to pin to 9x
- Handle warnings due to deprecation of negation operator