### PR TITLE
Remove None from list contains filters

### DIFF
--- a/generated_sql/bigquery/DT001-CountMatchingRows-validity_start_time_account_party_link.sql
+++ b/generated_sql/bigquery/DT001-CountMatchingRows-validity_start_time_account_party_link.sql
@@ -27,7 +27,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`account_party_link` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT001-CountMatchingRows-validity_start_time_party.sql
+++ b/generated_sql/bigquery/DT001-CountMatchingRows-validity_start_time_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT001-CountMatchingRows-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/bigquery/DT001-CountMatchingRows-validity_start_time_party_supplementary_data.sql
@@ -27,7 +27,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT001-CountMatchingRows-validity_start_time_transaction.sql
+++ b/generated_sql/bigquery/DT001-CountMatchingRows-validity_start_time_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT002-CountMatchingRows-birth_date_party.sql
+++ b/generated_sql/bigquery/DT002-CountMatchingRows-birth_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT003-CountMatchingRows-establishment_date_party.sql
+++ b/generated_sql/bigquery/DT003-CountMatchingRows-establishment_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT004-CountMatchingRows-exit_date_party.sql
+++ b/generated_sql/bigquery/DT004-CountMatchingRows-exit_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT005-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/bigquery/DT005-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT008-CountMatchingRows-book_time_transaction.sql
+++ b/generated_sql/bigquery/DT008-CountMatchingRows-book_time_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT012-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/bigquery/DT012-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT013-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/bigquery/DT013-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT017-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/bigquery/DT017-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/DT018-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/bigquery/DT018-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P001-CountFrequencyValues-validity_start_time_account_party_link.sql
+++ b/generated_sql/bigquery/P001-CountFrequencyValues-validity_start_time_account_party_link.sql
@@ -36,7 +36,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`account_party_link` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P001-CountFrequencyValues-validity_start_time_party.sql
+++ b/generated_sql/bigquery/P001-CountFrequencyValues-validity_start_time_party.sql
@@ -46,7 +46,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P001-CountFrequencyValues-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/bigquery/P001-CountFrequencyValues-validity_start_time_party_supplementary_data.sql
@@ -36,7 +36,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P001-CountFrequencyValues-validity_start_time_transaction.sql
+++ b/generated_sql/bigquery/P001-CountFrequencyValues-validity_start_time_transaction.sql
@@ -40,7 +40,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P002-ColumnCardinalityTest-source_system_party.sql
+++ b/generated_sql/bigquery/P002-ColumnCardinalityTest-source_system_party.sql
@@ -29,7 +29,11 @@ WITH `t3` AS (
         *
       FROM `PLACEHOLDER`.`party` AS `t0`
       WHERE
-        `t0`.`is_entity_deleted` IN (FALSE, NULL)
+        NOT (
+          `t0`.`is_entity_deleted`
+        ) OR (
+          `t0`.`is_entity_deleted` IS NULL
+        )
     ) AS `t1`
   ) AS `t2`
   WHERE

--- a/generated_sql/bigquery/P003-CountFrequencyValues-birth_date_party.sql
+++ b/generated_sql/bigquery/P003-CountFrequencyValues-birth_date_party.sql
@@ -46,7 +46,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P004-CountFrequencyValues-establishment_date_party.sql
+++ b/generated_sql/bigquery/P004-CountFrequencyValues-establishment_date_party.sql
@@ -46,7 +46,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P005-CountFrequencyValues-occupation_party.sql
+++ b/generated_sql/bigquery/P005-CountFrequencyValues-occupation_party.sql
@@ -46,7 +46,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P006-CountMatchingRows-nationalities_party.sql
+++ b/generated_sql/bigquery/P006-CountMatchingRows-nationalities_party.sql
@@ -41,7 +41,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P007-ColumnCardinalityTest-nationalities.region_code_party.sql
+++ b/generated_sql/bigquery/P007-ColumnCardinalityTest-nationalities.region_code_party.sql
@@ -60,7 +60,11 @@ FROM (
                 *
               FROM `PLACEHOLDER`.`party` AS `t0`
               WHERE
-                `t0`.`is_entity_deleted` IN (FALSE, NULL)
+                NOT (
+                  `t0`.`is_entity_deleted`
+                ) OR (
+                  `t0`.`is_entity_deleted` IS NULL
+                )
             ) AS `t1`
           ) AS `t2`
           WHERE

--- a/generated_sql/bigquery/P008-CountMatchingRows-residencies_party.sql
+++ b/generated_sql/bigquery/P008-CountMatchingRows-residencies_party.sql
@@ -41,7 +41,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P009-ColumnCardinalityTest-residencies.region_code_party.sql
+++ b/generated_sql/bigquery/P009-ColumnCardinalityTest-residencies.region_code_party.sql
@@ -60,7 +60,11 @@ FROM (
                 *
               FROM `PLACEHOLDER`.`party` AS `t0`
               WHERE
-                `t0`.`is_entity_deleted` IN (FALSE, NULL)
+                NOT (
+                  `t0`.`is_entity_deleted`
+                ) OR (
+                  `t0`.`is_entity_deleted` IS NULL
+                )
             ) AS `t1`
           ) AS `t2`
           WHERE

--- a/generated_sql/bigquery/P010-CountFrequencyValues-exit_date_party.sql
+++ b/generated_sql/bigquery/P010-CountFrequencyValues-exit_date_party.sql
@@ -46,7 +46,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P011-CountFrequencyValues-join_date_party.sql
+++ b/generated_sql/bigquery/P011-CountFrequencyValues-join_date_party.sql
@@ -46,7 +46,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P012-CountFrequencyValues-civil_status_code_party.sql
+++ b/generated_sql/bigquery/P012-CountFrequencyValues-civil_status_code_party.sql
@@ -46,7 +46,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P013-CountFrequencyValues-education_level_code_party.sql
+++ b/generated_sql/bigquery/P013-CountFrequencyValues-education_level_code_party.sql
@@ -46,7 +46,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P015-ColumnCardinalityTest-account_id_account_party_link.sql
+++ b/generated_sql/bigquery/P015-ColumnCardinalityTest-account_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P016-ColumnCardinalityTest-account_id_account_party_link.sql
+++ b/generated_sql/bigquery/P016-ColumnCardinalityTest-account_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P017-ColumnCardinalityTest-party_id_account_party_link.sql
+++ b/generated_sql/bigquery/P017-ColumnCardinalityTest-party_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P018-ColumnCardinalityTest-party_id_account_party_link.sql
+++ b/generated_sql/bigquery/P018-ColumnCardinalityTest-party_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P019-ColumnCardinalityTest-source_system_account_party_link.sql
+++ b/generated_sql/bigquery/P019-ColumnCardinalityTest-source_system_account_party_link.sql
@@ -19,7 +19,11 @@ WITH `t3` AS (
         *
       FROM `PLACEHOLDER`.`account_party_link` AS `t0`
       WHERE
-        `t0`.`is_entity_deleted` IN (FALSE, NULL)
+        NOT (
+          `t0`.`is_entity_deleted`
+        ) OR (
+          `t0`.`is_entity_deleted` IS NULL
+        )
     ) AS `t1`
   ) AS `t2`
   WHERE

--- a/generated_sql/bigquery/P021-ColumnCardinalityTest-source_system_transaction.sql
+++ b/generated_sql/bigquery/P021-ColumnCardinalityTest-source_system_transaction.sql
@@ -23,7 +23,11 @@ WITH `t3` AS (
         *
       FROM `PLACEHOLDER`.`transaction` AS `t0`
       WHERE
-        `t0`.`is_entity_deleted` IN (FALSE, NULL)
+        NOT (
+          `t0`.`is_entity_deleted`
+        ) OR (
+          `t0`.`is_entity_deleted` IS NULL
+        )
     ) AS `t1`
   ) AS `t2`
   WHERE

--- a/generated_sql/bigquery/P022-CARD-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/bigquery/P022-CARD-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P022-CASH-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/bigquery/P022-CASH-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P022-CHECK-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/bigquery/P022-CHECK-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P022-WIRE-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/bigquery/P022-WIRE-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P023-CREDIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/bigquery/P023-CREDIT-CountMatchingRows-direction_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P023-DEBIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/bigquery/P023-DEBIT-CountMatchingRows-direction_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P024-VerifyTypedValuePresence-direction_transaction.sql
+++ b/generated_sql/bigquery/P024-VerifyTypedValuePresence-direction_transaction.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P025-VerifyTypedValuePresence-direction_transaction.sql
+++ b/generated_sql/bigquery/P025-VerifyTypedValuePresence-direction_transaction.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P026-CountFrequencyValues-account_id_transaction.sql
+++ b/generated_sql/bigquery/P026-CountFrequencyValues-account_id_transaction.sql
@@ -40,7 +40,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P027-CountFrequencyValues-account_id_transaction.sql
+++ b/generated_sql/bigquery/P027-CountFrequencyValues-account_id_transaction.sql
@@ -40,7 +40,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P028-ColumnCardinalityTest-transaction_id_transaction.sql
+++ b/generated_sql/bigquery/P028-ColumnCardinalityTest-transaction_id_transaction.sql
@@ -33,7 +33,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`transaction` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P029-ColumnCardinalityTest-transaction_id_transaction.sql
+++ b/generated_sql/bigquery/P029-ColumnCardinalityTest-transaction_id_transaction.sql
@@ -33,7 +33,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`transaction` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P034-CountFrequencyValues-book_time_transaction.sql
+++ b/generated_sql/bigquery/P034-CountFrequencyValues-book_time_transaction.sql
@@ -40,7 +40,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P035-ConsistentIDsPerColumn-party_id_party_supplementary_data.sql
+++ b/generated_sql/bigquery/P035-ConsistentIDsPerColumn-party_id_party_supplementary_data.sql
@@ -9,10 +9,10 @@ FROM (
     ARRAY_TO_STRING(
       ARRAY(
         SELECT
-          ibis_bq_arr_5ehn25qlp5g57e4ydgwthvzbvm
-        FROM UNNEST(`t4`.`ids`) AS ibis_bq_arr_5ehn25qlp5g57e4ydgwthvzbvm
+          ibis_bq_arr_l5oaxvumufcophaetdfdqteadu
+        FROM UNNEST(`t4`.`ids`) AS ibis_bq_arr_l5oaxvumufcophaetdfdqteadu
         ORDER BY
-          ibis_bq_arr_5ehn25qlp5g57e4ydgwthvzbvm
+          ibis_bq_arr_l5oaxvumufcophaetdfdqteadu
       ),
       '|'
     ) AS `ids`
@@ -37,7 +37,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P036-ColumnCardinalityTest-party_supplementary_data_id_party_supplementary_data.sql
+++ b/generated_sql/bigquery/P036-ColumnCardinalityTest-party_supplementary_data_id_party_supplementary_data.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P037-ColumnCardinalityTest-source_system_party_supplementary_data.sql
+++ b/generated_sql/bigquery/P037-ColumnCardinalityTest-source_system_party_supplementary_data.sql
@@ -19,7 +19,11 @@ WITH `t3` AS (
         *
       FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
       WHERE
-        `t0`.`is_entity_deleted` IN (FALSE, NULL)
+        NOT (
+          `t0`.`is_entity_deleted`
+        ) OR (
+          `t0`.`is_entity_deleted` IS NULL
+        )
     ) AS `t1`
   ) AS `t2`
   WHERE

--- a/generated_sql/bigquery/P050-CountFrequencyValues-is_entity_deleted_account_party_link.sql
+++ b/generated_sql/bigquery/P050-CountFrequencyValues-is_entity_deleted_account_party_link.sql
@@ -36,7 +36,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`account_party_link` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P050-CountFrequencyValues-is_entity_deleted_party.sql
+++ b/generated_sql/bigquery/P050-CountFrequencyValues-is_entity_deleted_party.sql
@@ -46,7 +46,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P050-CountFrequencyValues-is_entity_deleted_party_supplementary_data.sql
+++ b/generated_sql/bigquery/P050-CountFrequencyValues-is_entity_deleted_party_supplementary_data.sql
@@ -36,7 +36,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P050-CountFrequencyValues-is_entity_deleted_transaction.sql
+++ b/generated_sql/bigquery/P050-CountFrequencyValues-is_entity_deleted_transaction.sql
@@ -40,7 +40,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P051-CountFrequencyValues_transaction.sql
+++ b/generated_sql/bigquery/P051-CountFrequencyValues_transaction.sql
@@ -1,4 +1,4 @@
--- Tests: transaction.<function <lambda> at 0x7f105c779300>
+-- Tests: transaction.<function <lambda> at 0x7f5fa342cea0>
 -- Severity: INFO
 -- Description: 5% of transactions have the same value across any transaction type
 -- Interpretation: When count > 0, verify nanos and units mapping. Why do so many transactions have the same transaction value?
@@ -44,7 +44,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/bigquery/P052-CountMatchingRows-book_time_transaction.sql
+++ b/generated_sql/bigquery/P052-CountMatchingRows-book_time_transaction.sql
@@ -36,7 +36,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P052-CountMatchingRows-validity_start_time_account_party_link.sql
+++ b/generated_sql/bigquery/P052-CountMatchingRows-validity_start_time_account_party_link.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`account_party_link` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P052-CountMatchingRows-validity_start_time_party.sql
+++ b/generated_sql/bigquery/P052-CountMatchingRows-validity_start_time_party.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P052-CountMatchingRows-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/bigquery/P052-CountMatchingRows-validity_start_time_party_supplementary_data.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P052-CountMatchingRows-validity_start_time_transaction.sql
+++ b/generated_sql/bigquery/P052-CountMatchingRows-validity_start_time_transaction.sql
@@ -36,7 +36,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/bigquery/P057-ColumnCardinalityTest-validity_start_time_account_party_link.sql
+++ b/generated_sql/bigquery/P057-ColumnCardinalityTest-validity_start_time_account_party_link.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P057-ColumnCardinalityTest-validity_start_time_party.sql
+++ b/generated_sql/bigquery/P057-ColumnCardinalityTest-validity_start_time_party.sql
@@ -38,7 +38,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P057-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/bigquery/P057-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P057-ColumnCardinalityTest-validity_start_time_transaction.sql
+++ b/generated_sql/bigquery/P057-ColumnCardinalityTest-validity_start_time_transaction.sql
@@ -32,7 +32,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`transaction` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P058-ColumnCardinalityTest-validity_start_time_account_party_link.sql
+++ b/generated_sql/bigquery/P058-ColumnCardinalityTest-validity_start_time_account_party_link.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P058-ColumnCardinalityTest-validity_start_time_party.sql
+++ b/generated_sql/bigquery/P058-ColumnCardinalityTest-validity_start_time_party.sql
@@ -38,7 +38,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P058-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/bigquery/P058-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/P058-ColumnCardinalityTest-validity_start_time_transaction.sql
+++ b/generated_sql/bigquery/P058-ColumnCardinalityTest-validity_start_time_transaction.sql
@@ -32,7 +32,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`transaction` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/bigquery/RI011-TemporalReferentialIntegrityTest_transaction.sql
+++ b/generated_sql/bigquery/RI011-TemporalReferentialIntegrityTest_transaction.sql
@@ -27,7 +27,11 @@ WITH `table` AS (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t2`
     ) AS `t4`
     WHERE

--- a/generated_sql/bigquery/V017-ColumnCardinalityTest-normalized_booked_amount.currency_code_transaction.sql
+++ b/generated_sql/bigquery/V017-ColumnCardinalityTest-normalized_booked_amount.currency_code_transaction.sql
@@ -22,7 +22,11 @@ WITH `t3` AS (
         *
       FROM `PLACEHOLDER`.`transaction` AS `t0`
       WHERE
-        `t0`.`is_entity_deleted` IN (FALSE, NULL)
+        NOT (
+          `t0`.`is_entity_deleted`
+        ) OR (
+          `t0`.`is_entity_deleted` IS NULL
+        )
     ) AS `t1`
   ) AS `t2`
   WHERE

--- a/generated_sql/duckdb/DT001-CountMatchingRows-validity_start_time_account_party_link.sql
+++ b/generated_sql/duckdb/DT001-CountMatchingRows-validity_start_time_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."account_party_link" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT001-CountMatchingRows-validity_start_time_party.sql
+++ b/generated_sql/duckdb/DT001-CountMatchingRows-validity_start_time_party.sql
@@ -38,7 +38,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT001-CountMatchingRows-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/duckdb/DT001-CountMatchingRows-validity_start_time_party_supplementary_data.sql
@@ -28,7 +28,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT001-CountMatchingRows-validity_start_time_transaction.sql
+++ b/generated_sql/duckdb/DT001-CountMatchingRows-validity_start_time_transaction.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT002-CountMatchingRows-birth_date_party.sql
+++ b/generated_sql/duckdb/DT002-CountMatchingRows-birth_date_party.sql
@@ -38,7 +38,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT003-CountMatchingRows-establishment_date_party.sql
+++ b/generated_sql/duckdb/DT003-CountMatchingRows-establishment_date_party.sql
@@ -38,7 +38,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT004-CountMatchingRows-exit_date_party.sql
+++ b/generated_sql/duckdb/DT004-CountMatchingRows-exit_date_party.sql
@@ -38,7 +38,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT005-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/duckdb/DT005-CountMatchingRows-join_date_party.sql
@@ -38,7 +38,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT008-CountMatchingRows-book_time_transaction.sql
+++ b/generated_sql/duckdb/DT008-CountMatchingRows-book_time_transaction.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT012-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/duckdb/DT012-CountMatchingRows-join_date_party.sql
@@ -38,7 +38,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT013-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/duckdb/DT013-CountMatchingRows-join_date_party.sql
@@ -38,7 +38,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT017-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/duckdb/DT017-CountMatchingRows-join_date_party.sql
@@ -38,7 +38,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/DT018-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/duckdb/DT018-CountMatchingRows-join_date_party.sql
@@ -38,7 +38,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P001-CountFrequencyValues-validity_start_time_account_party_link.sql
+++ b/generated_sql/duckdb/P001-CountFrequencyValues-validity_start_time_account_party_link.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."account_party_link" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P001-CountFrequencyValues-validity_start_time_party.sql
+++ b/generated_sql/duckdb/P001-CountFrequencyValues-validity_start_time_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P001-CountFrequencyValues-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/duckdb/P001-CountFrequencyValues-validity_start_time_party_supplementary_data.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P001-CountFrequencyValues-validity_start_time_transaction.sql
+++ b/generated_sql/duckdb/P001-CountFrequencyValues-validity_start_time_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P002-ColumnCardinalityTest-source_system_party.sql
+++ b/generated_sql/duckdb/P002-ColumnCardinalityTest-source_system_party.sql
@@ -29,7 +29,11 @@ WITH "t3" AS (
         *
       FROM "PLACEHOLDER"."party" AS "t0"
       WHERE
-        "t0"."is_entity_deleted" IN (FALSE, NULL)
+        NOT (
+          "t0"."is_entity_deleted"
+        ) OR (
+          "t0"."is_entity_deleted" IS NULL
+        )
     ) AS "t1"
   ) AS "t2"
   WHERE

--- a/generated_sql/duckdb/P003-CountFrequencyValues-birth_date_party.sql
+++ b/generated_sql/duckdb/P003-CountFrequencyValues-birth_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P004-CountFrequencyValues-establishment_date_party.sql
+++ b/generated_sql/duckdb/P004-CountFrequencyValues-establishment_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P005-CountFrequencyValues-occupation_party.sql
+++ b/generated_sql/duckdb/P005-CountFrequencyValues-occupation_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P006-CountMatchingRows-nationalities_party.sql
+++ b/generated_sql/duckdb/P006-CountMatchingRows-nationalities_party.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P007-ColumnCardinalityTest-nationalities.region_code_party.sql
+++ b/generated_sql/duckdb/P007-ColumnCardinalityTest-nationalities.region_code_party.sql
@@ -60,7 +60,11 @@ FROM (
                 *
               FROM "PLACEHOLDER"."party" AS "t0"
               WHERE
-                "t0"."is_entity_deleted" IN (FALSE, NULL)
+                NOT (
+                  "t0"."is_entity_deleted"
+                ) OR (
+                  "t0"."is_entity_deleted" IS NULL
+                )
             ) AS "t1"
           ) AS "t2"
           WHERE

--- a/generated_sql/duckdb/P008-CountMatchingRows-residencies_party.sql
+++ b/generated_sql/duckdb/P008-CountMatchingRows-residencies_party.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P009-ColumnCardinalityTest-residencies.region_code_party.sql
+++ b/generated_sql/duckdb/P009-ColumnCardinalityTest-residencies.region_code_party.sql
@@ -60,7 +60,11 @@ FROM (
                 *
               FROM "PLACEHOLDER"."party" AS "t0"
               WHERE
-                "t0"."is_entity_deleted" IN (FALSE, NULL)
+                NOT (
+                  "t0"."is_entity_deleted"
+                ) OR (
+                  "t0"."is_entity_deleted" IS NULL
+                )
             ) AS "t1"
           ) AS "t2"
           WHERE

--- a/generated_sql/duckdb/P010-CountFrequencyValues-exit_date_party.sql
+++ b/generated_sql/duckdb/P010-CountFrequencyValues-exit_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P011-CountFrequencyValues-join_date_party.sql
+++ b/generated_sql/duckdb/P011-CountFrequencyValues-join_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P012-CountFrequencyValues-civil_status_code_party.sql
+++ b/generated_sql/duckdb/P012-CountFrequencyValues-civil_status_code_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P013-CountFrequencyValues-education_level_code_party.sql
+++ b/generated_sql/duckdb/P013-CountFrequencyValues-education_level_code_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P015-ColumnCardinalityTest-account_id_account_party_link.sql
+++ b/generated_sql/duckdb/P015-ColumnCardinalityTest-account_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P016-ColumnCardinalityTest-account_id_account_party_link.sql
+++ b/generated_sql/duckdb/P016-ColumnCardinalityTest-account_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P017-ColumnCardinalityTest-party_id_account_party_link.sql
+++ b/generated_sql/duckdb/P017-ColumnCardinalityTest-party_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P018-ColumnCardinalityTest-party_id_account_party_link.sql
+++ b/generated_sql/duckdb/P018-ColumnCardinalityTest-party_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P019-ColumnCardinalityTest-source_system_account_party_link.sql
+++ b/generated_sql/duckdb/P019-ColumnCardinalityTest-source_system_account_party_link.sql
@@ -19,7 +19,11 @@ WITH "t3" AS (
         *
       FROM "PLACEHOLDER"."account_party_link" AS "t0"
       WHERE
-        "t0"."is_entity_deleted" IN (FALSE, NULL)
+        NOT (
+          "t0"."is_entity_deleted"
+        ) OR (
+          "t0"."is_entity_deleted" IS NULL
+        )
     ) AS "t1"
   ) AS "t2"
   WHERE

--- a/generated_sql/duckdb/P021-ColumnCardinalityTest-source_system_transaction.sql
+++ b/generated_sql/duckdb/P021-ColumnCardinalityTest-source_system_transaction.sql
@@ -23,7 +23,11 @@ WITH "t3" AS (
         *
       FROM "PLACEHOLDER"."transaction" AS "t0"
       WHERE
-        "t0"."is_entity_deleted" IN (FALSE, NULL)
+        NOT (
+          "t0"."is_entity_deleted"
+        ) OR (
+          "t0"."is_entity_deleted" IS NULL
+        )
     ) AS "t1"
   ) AS "t2"
   WHERE

--- a/generated_sql/duckdb/P022-CARD-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/duckdb/P022-CARD-CountMatchingRows-type_transaction.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P022-CASH-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/duckdb/P022-CASH-CountMatchingRows-type_transaction.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P022-CHECK-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/duckdb/P022-CHECK-CountMatchingRows-type_transaction.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P022-WIRE-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/duckdb/P022-WIRE-CountMatchingRows-type_transaction.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P023-CREDIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/duckdb/P023-CREDIT-CountMatchingRows-direction_transaction.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P023-DEBIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/duckdb/P023-DEBIT-CountMatchingRows-direction_transaction.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P024-VerifyTypedValuePresence-direction_transaction.sql
+++ b/generated_sql/duckdb/P024-VerifyTypedValuePresence-direction_transaction.sql
@@ -43,7 +43,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P025-VerifyTypedValuePresence-direction_transaction.sql
+++ b/generated_sql/duckdb/P025-VerifyTypedValuePresence-direction_transaction.sql
@@ -43,7 +43,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P026-CountFrequencyValues-account_id_transaction.sql
+++ b/generated_sql/duckdb/P026-CountFrequencyValues-account_id_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P027-CountFrequencyValues-account_id_transaction.sql
+++ b/generated_sql/duckdb/P027-CountFrequencyValues-account_id_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P028-ColumnCardinalityTest-transaction_id_transaction.sql
+++ b/generated_sql/duckdb/P028-ColumnCardinalityTest-transaction_id_transaction.sql
@@ -33,7 +33,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."transaction" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P029-ColumnCardinalityTest-transaction_id_transaction.sql
+++ b/generated_sql/duckdb/P029-ColumnCardinalityTest-transaction_id_transaction.sql
@@ -33,7 +33,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."transaction" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P034-CountFrequencyValues-book_time_transaction.sql
+++ b/generated_sql/duckdb/P034-CountFrequencyValues-book_time_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P035-ConsistentIDsPerColumn-party_id_party_supplementary_data.sql
+++ b/generated_sql/duckdb/P035-ConsistentIDsPerColumn-party_id_party_supplementary_data.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P036-ColumnCardinalityTest-party_supplementary_data_id_party_supplementary_data.sql
+++ b/generated_sql/duckdb/P036-ColumnCardinalityTest-party_supplementary_data_id_party_supplementary_data.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P037-ColumnCardinalityTest-source_system_party_supplementary_data.sql
+++ b/generated_sql/duckdb/P037-ColumnCardinalityTest-source_system_party_supplementary_data.sql
@@ -19,7 +19,11 @@ WITH "t3" AS (
         *
       FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
       WHERE
-        "t0"."is_entity_deleted" IN (FALSE, NULL)
+        NOT (
+          "t0"."is_entity_deleted"
+        ) OR (
+          "t0"."is_entity_deleted" IS NULL
+        )
     ) AS "t1"
   ) AS "t2"
   WHERE

--- a/generated_sql/duckdb/P050-CountFrequencyValues-is_entity_deleted_account_party_link.sql
+++ b/generated_sql/duckdb/P050-CountFrequencyValues-is_entity_deleted_account_party_link.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."account_party_link" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P050-CountFrequencyValues-is_entity_deleted_party.sql
+++ b/generated_sql/duckdb/P050-CountFrequencyValues-is_entity_deleted_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P050-CountFrequencyValues-is_entity_deleted_party_supplementary_data.sql
+++ b/generated_sql/duckdb/P050-CountFrequencyValues-is_entity_deleted_party_supplementary_data.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P050-CountFrequencyValues-is_entity_deleted_transaction.sql
+++ b/generated_sql/duckdb/P050-CountFrequencyValues-is_entity_deleted_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P051-CountFrequencyValues_transaction.sql
+++ b/generated_sql/duckdb/P051-CountFrequencyValues_transaction.sql
@@ -1,4 +1,4 @@
--- Tests: transaction.<function <lambda> at 0x7f78644b5300>
+-- Tests: transaction.<function <lambda> at 0x7f2ddc770ea0>
 -- Severity: INFO
 -- Description: 5% of transactions have the same value across any transaction type
 -- Interpretation: When count > 0, verify nanos and units mapping. Why do so many transactions have the same transaction value?
@@ -41,7 +41,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/duckdb/P052-CountMatchingRows-book_time_transaction.sql
+++ b/generated_sql/duckdb/P052-CountMatchingRows-book_time_transaction.sql
@@ -35,7 +35,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P052-CountMatchingRows-validity_start_time_account_party_link.sql
+++ b/generated_sql/duckdb/P052-CountMatchingRows-validity_start_time_account_party_link.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."account_party_link" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P052-CountMatchingRows-validity_start_time_party.sql
+++ b/generated_sql/duckdb/P052-CountMatchingRows-validity_start_time_party.sql
@@ -41,7 +41,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P052-CountMatchingRows-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/duckdb/P052-CountMatchingRows-validity_start_time_party_supplementary_data.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P052-CountMatchingRows-validity_start_time_transaction.sql
+++ b/generated_sql/duckdb/P052-CountMatchingRows-validity_start_time_transaction.sql
@@ -35,7 +35,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/duckdb/P057-ColumnCardinalityTest-validity_start_time_account_party_link.sql
+++ b/generated_sql/duckdb/P057-ColumnCardinalityTest-validity_start_time_account_party_link.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P057-ColumnCardinalityTest-validity_start_time_party.sql
+++ b/generated_sql/duckdb/P057-ColumnCardinalityTest-validity_start_time_party.sql
@@ -38,7 +38,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P057-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/duckdb/P057-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P057-ColumnCardinalityTest-validity_start_time_transaction.sql
+++ b/generated_sql/duckdb/P057-ColumnCardinalityTest-validity_start_time_transaction.sql
@@ -32,7 +32,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."transaction" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P058-ColumnCardinalityTest-validity_start_time_account_party_link.sql
+++ b/generated_sql/duckdb/P058-ColumnCardinalityTest-validity_start_time_account_party_link.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P058-ColumnCardinalityTest-validity_start_time_party.sql
+++ b/generated_sql/duckdb/P058-ColumnCardinalityTest-validity_start_time_party.sql
@@ -38,7 +38,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P058-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/duckdb/P058-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/P058-ColumnCardinalityTest-validity_start_time_transaction.sql
+++ b/generated_sql/duckdb/P058-ColumnCardinalityTest-validity_start_time_transaction.sql
@@ -32,7 +32,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."transaction" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/duckdb/RI011-TemporalReferentialIntegrityTest_transaction.sql
+++ b/generated_sql/duckdb/RI011-TemporalReferentialIntegrityTest_transaction.sql
@@ -27,7 +27,11 @@ WITH "table" AS (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t2"
     ) AS "t4"
     WHERE
@@ -42,8 +46,8 @@ WITH "table" AS (
     MAX("t10"."last_date") AS "last_date"
   FROM (
     SELECT
-      "t6"."account_id",
       "t6"."party_id",
+      "t6"."account_id",
       MIN("t6"."validity_start_time") AS "first_date",
       MAX(
         CASE
@@ -59,8 +63,8 @@ WITH "table" AS (
       ) AS "last_date"
     FROM (
       SELECT
-        "t3"."account_id",
         "t3"."party_id",
+        "t3"."account_id",
         "t3"."validity_start_time",
         "t3"."is_entity_deleted",
         "t3"."previous_entity_deleted",
@@ -75,13 +79,13 @@ WITH "table" AS (
         END AS "previous_row_validity_start_time"
       FROM (
         SELECT
-          "t1"."account_id",
           "t1"."party_id",
+          "t1"."account_id",
           "t1"."validity_start_time",
           COALESCE("t1"."is_entity_deleted", FALSE) AS "is_entity_deleted",
-          LAG(COALESCE("t1"."is_entity_deleted", FALSE)) OVER (PARTITION BY "t1"."account_id", "t1"."party_id" ORDER BY "t1"."validity_start_time" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "previous_entity_deleted",
-          LEAD("t1"."validity_start_time") OVER (PARTITION BY "t1"."account_id", "t1"."party_id" ORDER BY "t1"."validity_start_time" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "next_row_validity_start_time",
-          LAG("t1"."validity_start_time") OVER (PARTITION BY "t1"."account_id", "t1"."party_id" ORDER BY "t1"."validity_start_time" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "previous_row_validity_start_time"
+          LAG(COALESCE("t1"."is_entity_deleted", FALSE)) OVER (PARTITION BY "t1"."party_id", "t1"."account_id" ORDER BY "t1"."validity_start_time" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "previous_entity_deleted",
+          LEAD("t1"."validity_start_time") OVER (PARTITION BY "t1"."party_id", "t1"."account_id" ORDER BY "t1"."validity_start_time" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "next_row_validity_start_time",
+          LAG("t1"."validity_start_time") OVER (PARTITION BY "t1"."party_id", "t1"."account_id" ORDER BY "t1"."validity_start_time" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "previous_row_validity_start_time"
         FROM "PLACEHOLDER"."account_party_link" AS "t1"
       ) AS "t3"
       WHERE

--- a/generated_sql/duckdb/V017-ColumnCardinalityTest-normalized_booked_amount.currency_code_transaction.sql
+++ b/generated_sql/duckdb/V017-ColumnCardinalityTest-normalized_booked_amount.currency_code_transaction.sql
@@ -22,7 +22,11 @@ WITH "t3" AS (
         *
       FROM "PLACEHOLDER"."transaction" AS "t0"
       WHERE
-        "t0"."is_entity_deleted" IN (FALSE, NULL)
+        NOT (
+          "t0"."is_entity_deleted"
+        ) OR (
+          "t0"."is_entity_deleted" IS NULL
+        )
     ) AS "t1"
   ) AS "t2"
   WHERE

--- a/generated_sql/snowflake/DT001-CountMatchingRows-validity_start_time_account_party_link.sql
+++ b/generated_sql/snowflake/DT001-CountMatchingRows-validity_start_time_account_party_link.sql
@@ -27,7 +27,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."account_party_link" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT001-CountMatchingRows-validity_start_time_party.sql
+++ b/generated_sql/snowflake/DT001-CountMatchingRows-validity_start_time_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT001-CountMatchingRows-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/snowflake/DT001-CountMatchingRows-validity_start_time_party_supplementary_data.sql
@@ -27,7 +27,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT001-CountMatchingRows-validity_start_time_transaction.sql
+++ b/generated_sql/snowflake/DT001-CountMatchingRows-validity_start_time_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT002-CountMatchingRows-birth_date_party.sql
+++ b/generated_sql/snowflake/DT002-CountMatchingRows-birth_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT003-CountMatchingRows-establishment_date_party.sql
+++ b/generated_sql/snowflake/DT003-CountMatchingRows-establishment_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT004-CountMatchingRows-exit_date_party.sql
+++ b/generated_sql/snowflake/DT004-CountMatchingRows-exit_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT005-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/snowflake/DT005-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT008-CountMatchingRows-book_time_transaction.sql
+++ b/generated_sql/snowflake/DT008-CountMatchingRows-book_time_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT012-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/snowflake/DT012-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT013-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/snowflake/DT013-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT017-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/snowflake/DT017-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/DT018-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/snowflake/DT018-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P001-CountFrequencyValues-validity_start_time_account_party_link.sql
+++ b/generated_sql/snowflake/P001-CountFrequencyValues-validity_start_time_account_party_link.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."account_party_link" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P001-CountFrequencyValues-validity_start_time_party.sql
+++ b/generated_sql/snowflake/P001-CountFrequencyValues-validity_start_time_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P001-CountFrequencyValues-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/snowflake/P001-CountFrequencyValues-validity_start_time_party_supplementary_data.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P001-CountFrequencyValues-validity_start_time_transaction.sql
+++ b/generated_sql/snowflake/P001-CountFrequencyValues-validity_start_time_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P002-ColumnCardinalityTest-source_system_party.sql
+++ b/generated_sql/snowflake/P002-ColumnCardinalityTest-source_system_party.sql
@@ -29,7 +29,11 @@ WITH "t3" AS (
         *
       FROM "PLACEHOLDER"."party" AS "t0"
       WHERE
-        "t0"."is_entity_deleted" IN (FALSE, NULL)
+        NOT (
+          "t0"."is_entity_deleted"
+        ) OR (
+          "t0"."is_entity_deleted" IS NULL
+        )
     ) AS "t1"
   ) AS "t2"
   WHERE

--- a/generated_sql/snowflake/P003-CountFrequencyValues-birth_date_party.sql
+++ b/generated_sql/snowflake/P003-CountFrequencyValues-birth_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P004-CountFrequencyValues-establishment_date_party.sql
+++ b/generated_sql/snowflake/P004-CountFrequencyValues-establishment_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P005-CountFrequencyValues-occupation_party.sql
+++ b/generated_sql/snowflake/P005-CountFrequencyValues-occupation_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P006-CountMatchingRows-nationalities_party.sql
+++ b/generated_sql/snowflake/P006-CountMatchingRows-nationalities_party.sql
@@ -41,7 +41,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P007-ColumnCardinalityTest-nationalities.region_code_party.sql
+++ b/generated_sql/snowflake/P007-ColumnCardinalityTest-nationalities.region_code_party.sql
@@ -60,7 +60,11 @@ FROM (
                 *
               FROM "PLACEHOLDER"."party" AS "t0"
               WHERE
-                "t0"."is_entity_deleted" IN (FALSE, NULL)
+                NOT (
+                  "t0"."is_entity_deleted"
+                ) OR (
+                  "t0"."is_entity_deleted" IS NULL
+                )
             ) AS "t1"
           ) AS "t2"
           WHERE
@@ -72,16 +76,16 @@ FROM (
             GREATEST(
               ARRAY_SIZE(
                 SPLIT(
-                  ARRAY_TO_STRING(NULLIF("t3"."nationalities", []), 'b0495970e5ba4a93b1bdc924dcd2dd61'),
-                  'b0495970e5ba4a93b1bdc924dcd2dd61'
+                  ARRAY_TO_STRING(NULLIF("t3"."nationalities", []), 'cc42143ff1154f589e66c5b8f3916fe5'),
+                  'cc42143ff1154f589e66c5b8f3916fe5'
                 )
               )
             ) - 1
           ) + 1
         ))) AS _u(seq, key, path, index, pos, this)
         CROSS JOIN TABLE(FLATTEN(INPUT => SPLIT(
-          ARRAY_TO_STRING(NULLIF("t3"."nationalities", []), 'b0495970e5ba4a93b1bdc924dcd2dd61'),
-          'b0495970e5ba4a93b1bdc924dcd2dd61'
+          ARRAY_TO_STRING(NULLIF("t3"."nationalities", []), 'cc42143ff1154f589e66c5b8f3916fe5'),
+          'cc42143ff1154f589e66c5b8f3916fe5'
         ))) AS _u_2(seq, key, path, pos_2, "nationalities", this)
         WHERE
           _u.pos = _u_2.pos_2
@@ -89,16 +93,16 @@ FROM (
             _u.pos > (
               ARRAY_SIZE(
                 SPLIT(
-                  ARRAY_TO_STRING(NULLIF("t3"."nationalities", []), 'b0495970e5ba4a93b1bdc924dcd2dd61'),
-                  'b0495970e5ba4a93b1bdc924dcd2dd61'
+                  ARRAY_TO_STRING(NULLIF("t3"."nationalities", []), 'cc42143ff1154f589e66c5b8f3916fe5'),
+                  'cc42143ff1154f589e66c5b8f3916fe5'
                 )
               ) - 1
             )
             AND _u_2.pos_2 = (
               ARRAY_SIZE(
                 SPLIT(
-                  ARRAY_TO_STRING(NULLIF("t3"."nationalities", []), 'b0495970e5ba4a93b1bdc924dcd2dd61'),
-                  'b0495970e5ba4a93b1bdc924dcd2dd61'
+                  ARRAY_TO_STRING(NULLIF("t3"."nationalities", []), 'cc42143ff1154f589e66c5b8f3916fe5'),
+                  'cc42143ff1154f589e66c5b8f3916fe5'
                 )
               ) - 1
             )

--- a/generated_sql/snowflake/P008-CountMatchingRows-residencies_party.sql
+++ b/generated_sql/snowflake/P008-CountMatchingRows-residencies_party.sql
@@ -41,7 +41,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P009-ColumnCardinalityTest-residencies.region_code_party.sql
+++ b/generated_sql/snowflake/P009-ColumnCardinalityTest-residencies.region_code_party.sql
@@ -60,7 +60,11 @@ FROM (
                 *
               FROM "PLACEHOLDER"."party" AS "t0"
               WHERE
-                "t0"."is_entity_deleted" IN (FALSE, NULL)
+                NOT (
+                  "t0"."is_entity_deleted"
+                ) OR (
+                  "t0"."is_entity_deleted" IS NULL
+                )
             ) AS "t1"
           ) AS "t2"
           WHERE
@@ -72,16 +76,16 @@ FROM (
             GREATEST(
               ARRAY_SIZE(
                 SPLIT(
-                  ARRAY_TO_STRING(NULLIF("t3"."residencies", []), '7281bbbf1b7f4b03b668b9c769b036b0'),
-                  '7281bbbf1b7f4b03b668b9c769b036b0'
+                  ARRAY_TO_STRING(NULLIF("t3"."residencies", []), '7631081ca64945a7a6912fda3e80cb01'),
+                  '7631081ca64945a7a6912fda3e80cb01'
                 )
               )
             ) - 1
           ) + 1
         ))) AS _u(seq, key, path, index, pos, this)
         CROSS JOIN TABLE(FLATTEN(INPUT => SPLIT(
-          ARRAY_TO_STRING(NULLIF("t3"."residencies", []), '7281bbbf1b7f4b03b668b9c769b036b0'),
-          '7281bbbf1b7f4b03b668b9c769b036b0'
+          ARRAY_TO_STRING(NULLIF("t3"."residencies", []), '7631081ca64945a7a6912fda3e80cb01'),
+          '7631081ca64945a7a6912fda3e80cb01'
         ))) AS _u_2(seq, key, path, pos_2, "residencies", this)
         WHERE
           _u.pos = _u_2.pos_2
@@ -89,16 +93,16 @@ FROM (
             _u.pos > (
               ARRAY_SIZE(
                 SPLIT(
-                  ARRAY_TO_STRING(NULLIF("t3"."residencies", []), '7281bbbf1b7f4b03b668b9c769b036b0'),
-                  '7281bbbf1b7f4b03b668b9c769b036b0'
+                  ARRAY_TO_STRING(NULLIF("t3"."residencies", []), '7631081ca64945a7a6912fda3e80cb01'),
+                  '7631081ca64945a7a6912fda3e80cb01'
                 )
               ) - 1
             )
             AND _u_2.pos_2 = (
               ARRAY_SIZE(
                 SPLIT(
-                  ARRAY_TO_STRING(NULLIF("t3"."residencies", []), '7281bbbf1b7f4b03b668b9c769b036b0'),
-                  '7281bbbf1b7f4b03b668b9c769b036b0'
+                  ARRAY_TO_STRING(NULLIF("t3"."residencies", []), '7631081ca64945a7a6912fda3e80cb01'),
+                  '7631081ca64945a7a6912fda3e80cb01'
                 )
               ) - 1
             )

--- a/generated_sql/snowflake/P010-CountFrequencyValues-exit_date_party.sql
+++ b/generated_sql/snowflake/P010-CountFrequencyValues-exit_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P011-CountFrequencyValues-join_date_party.sql
+++ b/generated_sql/snowflake/P011-CountFrequencyValues-join_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P012-CountFrequencyValues-civil_status_code_party.sql
+++ b/generated_sql/snowflake/P012-CountFrequencyValues-civil_status_code_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P013-CountFrequencyValues-education_level_code_party.sql
+++ b/generated_sql/snowflake/P013-CountFrequencyValues-education_level_code_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P015-ColumnCardinalityTest-account_id_account_party_link.sql
+++ b/generated_sql/snowflake/P015-ColumnCardinalityTest-account_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P016-ColumnCardinalityTest-account_id_account_party_link.sql
+++ b/generated_sql/snowflake/P016-ColumnCardinalityTest-account_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P017-ColumnCardinalityTest-party_id_account_party_link.sql
+++ b/generated_sql/snowflake/P017-ColumnCardinalityTest-party_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P018-ColumnCardinalityTest-party_id_account_party_link.sql
+++ b/generated_sql/snowflake/P018-ColumnCardinalityTest-party_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P019-ColumnCardinalityTest-source_system_account_party_link.sql
+++ b/generated_sql/snowflake/P019-ColumnCardinalityTest-source_system_account_party_link.sql
@@ -19,7 +19,11 @@ WITH "t3" AS (
         *
       FROM "PLACEHOLDER"."account_party_link" AS "t0"
       WHERE
-        "t0"."is_entity_deleted" IN (FALSE, NULL)
+        NOT (
+          "t0"."is_entity_deleted"
+        ) OR (
+          "t0"."is_entity_deleted" IS NULL
+        )
     ) AS "t1"
   ) AS "t2"
   WHERE

--- a/generated_sql/snowflake/P021-ColumnCardinalityTest-source_system_transaction.sql
+++ b/generated_sql/snowflake/P021-ColumnCardinalityTest-source_system_transaction.sql
@@ -23,7 +23,11 @@ WITH "t3" AS (
         *
       FROM "PLACEHOLDER"."transaction" AS "t0"
       WHERE
-        "t0"."is_entity_deleted" IN (FALSE, NULL)
+        NOT (
+          "t0"."is_entity_deleted"
+        ) OR (
+          "t0"."is_entity_deleted" IS NULL
+        )
     ) AS "t1"
   ) AS "t2"
   WHERE

--- a/generated_sql/snowflake/P022-CARD-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/snowflake/P022-CARD-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P022-CASH-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/snowflake/P022-CASH-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P022-CHECK-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/snowflake/P022-CHECK-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P022-WIRE-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/snowflake/P022-WIRE-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P023-CREDIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/snowflake/P023-CREDIT-CountMatchingRows-direction_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P023-DEBIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/snowflake/P023-DEBIT-CountMatchingRows-direction_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P024-VerifyTypedValuePresence-direction_transaction.sql
+++ b/generated_sql/snowflake/P024-VerifyTypedValuePresence-direction_transaction.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P025-VerifyTypedValuePresence-direction_transaction.sql
+++ b/generated_sql/snowflake/P025-VerifyTypedValuePresence-direction_transaction.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P026-CountFrequencyValues-account_id_transaction.sql
+++ b/generated_sql/snowflake/P026-CountFrequencyValues-account_id_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P027-CountFrequencyValues-account_id_transaction.sql
+++ b/generated_sql/snowflake/P027-CountFrequencyValues-account_id_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P028-ColumnCardinalityTest-transaction_id_transaction.sql
+++ b/generated_sql/snowflake/P028-ColumnCardinalityTest-transaction_id_transaction.sql
@@ -33,7 +33,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."transaction" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P029-ColumnCardinalityTest-transaction_id_transaction.sql
+++ b/generated_sql/snowflake/P029-ColumnCardinalityTest-transaction_id_transaction.sql
@@ -33,7 +33,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."transaction" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P034-CountFrequencyValues-book_time_transaction.sql
+++ b/generated_sql/snowflake/P034-CountFrequencyValues-book_time_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P035-ConsistentIDsPerColumn-party_id_party_supplementary_data.sql
+++ b/generated_sql/snowflake/P035-ConsistentIDsPerColumn-party_id_party_supplementary_data.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P036-ColumnCardinalityTest-party_supplementary_data_id_party_supplementary_data.sql
+++ b/generated_sql/snowflake/P036-ColumnCardinalityTest-party_supplementary_data_id_party_supplementary_data.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P037-ColumnCardinalityTest-source_system_party_supplementary_data.sql
+++ b/generated_sql/snowflake/P037-ColumnCardinalityTest-source_system_party_supplementary_data.sql
@@ -19,7 +19,11 @@ WITH "t3" AS (
         *
       FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
       WHERE
-        "t0"."is_entity_deleted" IN (FALSE, NULL)
+        NOT (
+          "t0"."is_entity_deleted"
+        ) OR (
+          "t0"."is_entity_deleted" IS NULL
+        )
     ) AS "t1"
   ) AS "t2"
   WHERE

--- a/generated_sql/snowflake/P050-CountFrequencyValues-is_entity_deleted_account_party_link.sql
+++ b/generated_sql/snowflake/P050-CountFrequencyValues-is_entity_deleted_account_party_link.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."account_party_link" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P050-CountFrequencyValues-is_entity_deleted_party.sql
+++ b/generated_sql/snowflake/P050-CountFrequencyValues-is_entity_deleted_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P050-CountFrequencyValues-is_entity_deleted_party_supplementary_data.sql
+++ b/generated_sql/snowflake/P050-CountFrequencyValues-is_entity_deleted_party_supplementary_data.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P050-CountFrequencyValues-is_entity_deleted_transaction.sql
+++ b/generated_sql/snowflake/P050-CountFrequencyValues-is_entity_deleted_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P051-CountFrequencyValues_transaction.sql
+++ b/generated_sql/snowflake/P051-CountFrequencyValues_transaction.sql
@@ -1,4 +1,4 @@
--- Tests: transaction.<function <lambda> at 0x7f4ee8e01300>
+-- Tests: transaction.<function <lambda> at 0x7fc249eb8ea0>
 -- Severity: INFO
 -- Description: 5% of transactions have the same value across any transaction type
 -- Interpretation: When count > 0, verify nanos and units mapping. Why do so many transactions have the same transaction value?
@@ -41,7 +41,11 @@ FROM (
               *
             FROM "PLACEHOLDER"."transaction" AS "t0"
             WHERE
-              "t0"."is_entity_deleted" IN (FALSE, NULL)
+              NOT (
+                "t0"."is_entity_deleted"
+              ) OR (
+                "t0"."is_entity_deleted" IS NULL
+              )
           ) AS "t1"
         ) AS "t2"
         WHERE

--- a/generated_sql/snowflake/P052-CountMatchingRows-book_time_transaction.sql
+++ b/generated_sql/snowflake/P052-CountMatchingRows-book_time_transaction.sql
@@ -36,7 +36,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P052-CountMatchingRows-validity_start_time_account_party_link.sql
+++ b/generated_sql/snowflake/P052-CountMatchingRows-validity_start_time_account_party_link.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."account_party_link" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P052-CountMatchingRows-validity_start_time_party.sql
+++ b/generated_sql/snowflake/P052-CountMatchingRows-validity_start_time_party.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P052-CountMatchingRows-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/snowflake/P052-CountMatchingRows-validity_start_time_party_supplementary_data.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P052-CountMatchingRows-validity_start_time_transaction.sql
+++ b/generated_sql/snowflake/P052-CountMatchingRows-validity_start_time_transaction.sql
@@ -36,7 +36,11 @@ FROM (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t1"
     ) AS "t2"
     WHERE

--- a/generated_sql/snowflake/P057-ColumnCardinalityTest-validity_start_time_account_party_link.sql
+++ b/generated_sql/snowflake/P057-ColumnCardinalityTest-validity_start_time_account_party_link.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P057-ColumnCardinalityTest-validity_start_time_party.sql
+++ b/generated_sql/snowflake/P057-ColumnCardinalityTest-validity_start_time_party.sql
@@ -38,7 +38,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P057-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/snowflake/P057-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P057-ColumnCardinalityTest-validity_start_time_transaction.sql
+++ b/generated_sql/snowflake/P057-ColumnCardinalityTest-validity_start_time_transaction.sql
@@ -32,7 +32,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."transaction" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P058-ColumnCardinalityTest-validity_start_time_account_party_link.sql
+++ b/generated_sql/snowflake/P058-ColumnCardinalityTest-validity_start_time_account_party_link.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."account_party_link" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P058-ColumnCardinalityTest-validity_start_time_party.sql
+++ b/generated_sql/snowflake/P058-ColumnCardinalityTest-validity_start_time_party.sql
@@ -38,7 +38,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P058-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/snowflake/P058-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."party_supplementary_data" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/P058-ColumnCardinalityTest-validity_start_time_transaction.sql
+++ b/generated_sql/snowflake/P058-ColumnCardinalityTest-validity_start_time_transaction.sql
@@ -32,7 +32,11 @@ FROM (
             *
           FROM "PLACEHOLDER"."transaction" AS "t0"
           WHERE
-            "t0"."is_entity_deleted" IN (FALSE, NULL)
+            NOT (
+              "t0"."is_entity_deleted"
+            ) OR (
+              "t0"."is_entity_deleted" IS NULL
+            )
         ) AS "t1"
       ) AS "t2"
       WHERE

--- a/generated_sql/snowflake/RI011-TemporalReferentialIntegrityTest_transaction.sql
+++ b/generated_sql/snowflake/RI011-TemporalReferentialIntegrityTest_transaction.sql
@@ -27,7 +27,11 @@ WITH "table" AS (
           *
         FROM "PLACEHOLDER"."transaction" AS "t0"
         WHERE
-          "t0"."is_entity_deleted" IN (FALSE, NULL)
+          NOT (
+            "t0"."is_entity_deleted"
+          ) OR (
+            "t0"."is_entity_deleted" IS NULL
+          )
       ) AS "t2"
     ) AS "t4"
     WHERE
@@ -42,8 +46,8 @@ WITH "table" AS (
     MAX("t10"."last_date") AS "last_date"
   FROM (
     SELECT
-      "t6"."party_id",
       "t6"."account_id",
+      "t6"."party_id",
       MIN("t6"."validity_start_time") AS "first_date",
       MAX(
         IFF(
@@ -59,8 +63,8 @@ WITH "table" AS (
       ) AS "last_date"
     FROM (
       SELECT
-        "t3"."party_id",
         "t3"."account_id",
+        "t3"."party_id",
         "t3"."validity_start_time",
         "t3"."is_entity_deleted",
         "t3"."previous_entity_deleted",
@@ -75,13 +79,13 @@ WITH "table" AS (
         ) AS "previous_row_validity_start_time"
       FROM (
         SELECT
-          "t1"."party_id",
           "t1"."account_id",
+          "t1"."party_id",
           "t1"."validity_start_time",
           COALESCE("t1"."is_entity_deleted", FALSE) AS "is_entity_deleted",
-          LAG(COALESCE("t1"."is_entity_deleted", FALSE)) OVER (PARTITION BY "t1"."party_id", "t1"."account_id" ORDER BY "t1"."validity_start_time" ASC) AS "previous_entity_deleted",
-          LEAD("t1"."validity_start_time") OVER (PARTITION BY "t1"."party_id", "t1"."account_id" ORDER BY "t1"."validity_start_time" ASC) AS "next_row_validity_start_time",
-          LAG("t1"."validity_start_time") OVER (PARTITION BY "t1"."party_id", "t1"."account_id" ORDER BY "t1"."validity_start_time" ASC) AS "previous_row_validity_start_time"
+          LAG(COALESCE("t1"."is_entity_deleted", FALSE)) OVER (PARTITION BY "t1"."account_id", "t1"."party_id" ORDER BY "t1"."validity_start_time" ASC) AS "previous_entity_deleted",
+          LEAD("t1"."validity_start_time") OVER (PARTITION BY "t1"."account_id", "t1"."party_id" ORDER BY "t1"."validity_start_time" ASC) AS "next_row_validity_start_time",
+          LAG("t1"."validity_start_time") OVER (PARTITION BY "t1"."account_id", "t1"."party_id" ORDER BY "t1"."validity_start_time" ASC) AS "previous_row_validity_start_time"
         FROM "PLACEHOLDER"."account_party_link" AS "t1"
       ) AS "t3"
       WHERE

--- a/generated_sql/snowflake/V017-ColumnCardinalityTest-normalized_booked_amount.currency_code_transaction.sql
+++ b/generated_sql/snowflake/V017-ColumnCardinalityTest-normalized_booked_amount.currency_code_transaction.sql
@@ -22,7 +22,11 @@ WITH "t3" AS (
         *
       FROM "PLACEHOLDER"."transaction" AS "t0"
       WHERE
-        "t0"."is_entity_deleted" IN (FALSE, NULL)
+        NOT (
+          "t0"."is_entity_deleted"
+        ) OR (
+          "t0"."is_entity_deleted" IS NULL
+        )
     ) AS "t1"
   ) AS "t2"
   WHERE

--- a/generated_sql/spark-sql/DT001-CountMatchingRows-validity_start_time_account_party_link.sql
+++ b/generated_sql/spark-sql/DT001-CountMatchingRows-validity_start_time_account_party_link.sql
@@ -27,7 +27,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`account_party_link` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT001-CountMatchingRows-validity_start_time_party.sql
+++ b/generated_sql/spark-sql/DT001-CountMatchingRows-validity_start_time_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT001-CountMatchingRows-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/spark-sql/DT001-CountMatchingRows-validity_start_time_party_supplementary_data.sql
@@ -27,7 +27,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT001-CountMatchingRows-validity_start_time_transaction.sql
+++ b/generated_sql/spark-sql/DT001-CountMatchingRows-validity_start_time_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT002-CountMatchingRows-birth_date_party.sql
+++ b/generated_sql/spark-sql/DT002-CountMatchingRows-birth_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT003-CountMatchingRows-establishment_date_party.sql
+++ b/generated_sql/spark-sql/DT003-CountMatchingRows-establishment_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT004-CountMatchingRows-exit_date_party.sql
+++ b/generated_sql/spark-sql/DT004-CountMatchingRows-exit_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT005-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/spark-sql/DT005-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT008-CountMatchingRows-book_time_transaction.sql
+++ b/generated_sql/spark-sql/DT008-CountMatchingRows-book_time_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT012-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/spark-sql/DT012-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT013-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/spark-sql/DT013-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT017-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/spark-sql/DT017-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/DT018-CountMatchingRows-join_date_party.sql
+++ b/generated_sql/spark-sql/DT018-CountMatchingRows-join_date_party.sql
@@ -37,7 +37,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P001-CountFrequencyValues-validity_start_time_account_party_link.sql
+++ b/generated_sql/spark-sql/P001-CountFrequencyValues-validity_start_time_account_party_link.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`account_party_link` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P001-CountFrequencyValues-validity_start_time_party.sql
+++ b/generated_sql/spark-sql/P001-CountFrequencyValues-validity_start_time_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P001-CountFrequencyValues-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/spark-sql/P001-CountFrequencyValues-validity_start_time_party_supplementary_data.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P001-CountFrequencyValues-validity_start_time_transaction.sql
+++ b/generated_sql/spark-sql/P001-CountFrequencyValues-validity_start_time_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P002-ColumnCardinalityTest-source_system_party.sql
+++ b/generated_sql/spark-sql/P002-ColumnCardinalityTest-source_system_party.sql
@@ -29,7 +29,11 @@ WITH `t3` AS (
         *
       FROM `PLACEHOLDER`.`party` AS `t0`
       WHERE
-        `t0`.`is_entity_deleted` IN (FALSE, NULL)
+        NOT (
+          `t0`.`is_entity_deleted`
+        ) OR (
+          `t0`.`is_entity_deleted` IS NULL
+        )
     ) AS `t1`
   ) AS `t2`
   WHERE

--- a/generated_sql/spark-sql/P003-CountFrequencyValues-birth_date_party.sql
+++ b/generated_sql/spark-sql/P003-CountFrequencyValues-birth_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P004-CountFrequencyValues-establishment_date_party.sql
+++ b/generated_sql/spark-sql/P004-CountFrequencyValues-establishment_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P005-CountFrequencyValues-occupation_party.sql
+++ b/generated_sql/spark-sql/P005-CountFrequencyValues-occupation_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P006-CountMatchingRows-nationalities_party.sql
+++ b/generated_sql/spark-sql/P006-CountMatchingRows-nationalities_party.sql
@@ -43,7 +43,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P007-ColumnCardinalityTest-nationalities.region_code_party.sql
+++ b/generated_sql/spark-sql/P007-ColumnCardinalityTest-nationalities.region_code_party.sql
@@ -60,7 +60,11 @@ FROM (
                 *
               FROM `PLACEHOLDER`.`party` AS `t0`
               WHERE
-                `t0`.`is_entity_deleted` IN (FALSE, NULL)
+                NOT (
+                  `t0`.`is_entity_deleted`
+                ) OR (
+                  `t0`.`is_entity_deleted` IS NULL
+                )
             ) AS `t1`
           ) AS `t2`
           WHERE

--- a/generated_sql/spark-sql/P008-CountMatchingRows-residencies_party.sql
+++ b/generated_sql/spark-sql/P008-CountMatchingRows-residencies_party.sql
@@ -43,7 +43,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P009-ColumnCardinalityTest-residencies.region_code_party.sql
+++ b/generated_sql/spark-sql/P009-ColumnCardinalityTest-residencies.region_code_party.sql
@@ -60,7 +60,11 @@ FROM (
                 *
               FROM `PLACEHOLDER`.`party` AS `t0`
               WHERE
-                `t0`.`is_entity_deleted` IN (FALSE, NULL)
+                NOT (
+                  `t0`.`is_entity_deleted`
+                ) OR (
+                  `t0`.`is_entity_deleted` IS NULL
+                )
             ) AS `t1`
           ) AS `t2`
           WHERE

--- a/generated_sql/spark-sql/P010-CountFrequencyValues-exit_date_party.sql
+++ b/generated_sql/spark-sql/P010-CountFrequencyValues-exit_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P011-CountFrequencyValues-join_date_party.sql
+++ b/generated_sql/spark-sql/P011-CountFrequencyValues-join_date_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P012-CountFrequencyValues-civil_status_code_party.sql
+++ b/generated_sql/spark-sql/P012-CountFrequencyValues-civil_status_code_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P013-CountFrequencyValues-education_level_code_party.sql
+++ b/generated_sql/spark-sql/P013-CountFrequencyValues-education_level_code_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P015-ColumnCardinalityTest-account_id_account_party_link.sql
+++ b/generated_sql/spark-sql/P015-ColumnCardinalityTest-account_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P016-ColumnCardinalityTest-account_id_account_party_link.sql
+++ b/generated_sql/spark-sql/P016-ColumnCardinalityTest-account_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P017-ColumnCardinalityTest-party_id_account_party_link.sql
+++ b/generated_sql/spark-sql/P017-ColumnCardinalityTest-party_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P018-ColumnCardinalityTest-party_id_account_party_link.sql
+++ b/generated_sql/spark-sql/P018-ColumnCardinalityTest-party_id_account_party_link.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P019-ColumnCardinalityTest-source_system_account_party_link.sql
+++ b/generated_sql/spark-sql/P019-ColumnCardinalityTest-source_system_account_party_link.sql
@@ -19,7 +19,11 @@ WITH `t3` AS (
         *
       FROM `PLACEHOLDER`.`account_party_link` AS `t0`
       WHERE
-        `t0`.`is_entity_deleted` IN (FALSE, NULL)
+        NOT (
+          `t0`.`is_entity_deleted`
+        ) OR (
+          `t0`.`is_entity_deleted` IS NULL
+        )
     ) AS `t1`
   ) AS `t2`
   WHERE

--- a/generated_sql/spark-sql/P021-ColumnCardinalityTest-source_system_transaction.sql
+++ b/generated_sql/spark-sql/P021-ColumnCardinalityTest-source_system_transaction.sql
@@ -23,7 +23,11 @@ WITH `t3` AS (
         *
       FROM `PLACEHOLDER`.`transaction` AS `t0`
       WHERE
-        `t0`.`is_entity_deleted` IN (FALSE, NULL)
+        NOT (
+          `t0`.`is_entity_deleted`
+        ) OR (
+          `t0`.`is_entity_deleted` IS NULL
+        )
     ) AS `t1`
   ) AS `t2`
   WHERE

--- a/generated_sql/spark-sql/P022-CARD-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/spark-sql/P022-CARD-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P022-CASH-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/spark-sql/P022-CASH-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P022-CHECK-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/spark-sql/P022-CHECK-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P022-WIRE-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/spark-sql/P022-WIRE-CountMatchingRows-type_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P023-CREDIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/spark-sql/P023-CREDIT-CountMatchingRows-direction_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P023-DEBIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/spark-sql/P023-DEBIT-CountMatchingRows-direction_transaction.sql
@@ -31,7 +31,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P024-VerifyTypedValuePresence-direction_transaction.sql
+++ b/generated_sql/spark-sql/P024-VerifyTypedValuePresence-direction_transaction.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P025-VerifyTypedValuePresence-direction_transaction.sql
+++ b/generated_sql/spark-sql/P025-VerifyTypedValuePresence-direction_transaction.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P026-CountFrequencyValues-account_id_transaction.sql
+++ b/generated_sql/spark-sql/P026-CountFrequencyValues-account_id_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P027-CountFrequencyValues-account_id_transaction.sql
+++ b/generated_sql/spark-sql/P027-CountFrequencyValues-account_id_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P028-ColumnCardinalityTest-transaction_id_transaction.sql
+++ b/generated_sql/spark-sql/P028-ColumnCardinalityTest-transaction_id_transaction.sql
@@ -33,7 +33,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`transaction` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P029-ColumnCardinalityTest-transaction_id_transaction.sql
+++ b/generated_sql/spark-sql/P029-ColumnCardinalityTest-transaction_id_transaction.sql
@@ -33,7 +33,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`transaction` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P034-CountFrequencyValues-book_time_transaction.sql
+++ b/generated_sql/spark-sql/P034-CountFrequencyValues-book_time_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P035-ConsistentIDsPerColumn-party_id_party_supplementary_data.sql
+++ b/generated_sql/spark-sql/P035-ConsistentIDsPerColumn-party_id_party_supplementary_data.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P036-ColumnCardinalityTest-party_supplementary_data_id_party_supplementary_data.sql
+++ b/generated_sql/spark-sql/P036-ColumnCardinalityTest-party_supplementary_data_id_party_supplementary_data.sql
@@ -28,7 +28,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P037-ColumnCardinalityTest-source_system_party_supplementary_data.sql
+++ b/generated_sql/spark-sql/P037-ColumnCardinalityTest-source_system_party_supplementary_data.sql
@@ -19,7 +19,11 @@ WITH `t3` AS (
         *
       FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
       WHERE
-        `t0`.`is_entity_deleted` IN (FALSE, NULL)
+        NOT (
+          `t0`.`is_entity_deleted`
+        ) OR (
+          `t0`.`is_entity_deleted` IS NULL
+        )
     ) AS `t1`
   ) AS `t2`
   WHERE

--- a/generated_sql/spark-sql/P050-CountFrequencyValues-is_entity_deleted_account_party_link.sql
+++ b/generated_sql/spark-sql/P050-CountFrequencyValues-is_entity_deleted_account_party_link.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`account_party_link` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P050-CountFrequencyValues-is_entity_deleted_party.sql
+++ b/generated_sql/spark-sql/P050-CountFrequencyValues-is_entity_deleted_party.sql
@@ -43,7 +43,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P050-CountFrequencyValues-is_entity_deleted_party_supplementary_data.sql
+++ b/generated_sql/spark-sql/P050-CountFrequencyValues-is_entity_deleted_party_supplementary_data.sql
@@ -33,7 +33,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P050-CountFrequencyValues-is_entity_deleted_transaction.sql
+++ b/generated_sql/spark-sql/P050-CountFrequencyValues-is_entity_deleted_transaction.sql
@@ -37,7 +37,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P051-CountFrequencyValues_transaction.sql
+++ b/generated_sql/spark-sql/P051-CountFrequencyValues_transaction.sql
@@ -1,4 +1,4 @@
--- Tests: transaction.<function <lambda> at 0x7fe5f1ba5300>
+-- Tests: transaction.<function <lambda> at 0x7f0cd0dbcea0>
 -- Severity: INFO
 -- Description: 5% of transactions have the same value across any transaction type
 -- Interpretation: When count > 0, verify nanos and units mapping. Why do so many transactions have the same transaction value?
@@ -41,7 +41,11 @@ FROM (
               *
             FROM `PLACEHOLDER`.`transaction` AS `t0`
             WHERE
-              `t0`.`is_entity_deleted` IN (FALSE, NULL)
+              NOT (
+                `t0`.`is_entity_deleted`
+              ) OR (
+                `t0`.`is_entity_deleted` IS NULL
+              )
           ) AS `t1`
         ) AS `t2`
         WHERE

--- a/generated_sql/spark-sql/P052-CountMatchingRows-book_time_transaction.sql
+++ b/generated_sql/spark-sql/P052-CountMatchingRows-book_time_transaction.sql
@@ -36,7 +36,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P052-CountMatchingRows-validity_start_time_account_party_link.sql
+++ b/generated_sql/spark-sql/P052-CountMatchingRows-validity_start_time_account_party_link.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`account_party_link` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P052-CountMatchingRows-validity_start_time_party.sql
+++ b/generated_sql/spark-sql/P052-CountMatchingRows-validity_start_time_party.sql
@@ -42,7 +42,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P052-CountMatchingRows-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/spark-sql/P052-CountMatchingRows-validity_start_time_party_supplementary_data.sql
@@ -32,7 +32,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P052-CountMatchingRows-validity_start_time_transaction.sql
+++ b/generated_sql/spark-sql/P052-CountMatchingRows-validity_start_time_transaction.sql
@@ -36,7 +36,11 @@ FROM (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t1`
     ) AS `t2`
     WHERE

--- a/generated_sql/spark-sql/P057-ColumnCardinalityTest-validity_start_time_account_party_link.sql
+++ b/generated_sql/spark-sql/P057-ColumnCardinalityTest-validity_start_time_account_party_link.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P057-ColumnCardinalityTest-validity_start_time_party.sql
+++ b/generated_sql/spark-sql/P057-ColumnCardinalityTest-validity_start_time_party.sql
@@ -38,7 +38,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P057-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/spark-sql/P057-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P057-ColumnCardinalityTest-validity_start_time_transaction.sql
+++ b/generated_sql/spark-sql/P057-ColumnCardinalityTest-validity_start_time_transaction.sql
@@ -32,7 +32,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`transaction` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P058-ColumnCardinalityTest-validity_start_time_account_party_link.sql
+++ b/generated_sql/spark-sql/P058-ColumnCardinalityTest-validity_start_time_account_party_link.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`account_party_link` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P058-ColumnCardinalityTest-validity_start_time_party.sql
+++ b/generated_sql/spark-sql/P058-ColumnCardinalityTest-validity_start_time_party.sql
@@ -38,7 +38,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P058-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
+++ b/generated_sql/spark-sql/P058-ColumnCardinalityTest-validity_start_time_party_supplementary_data.sql
@@ -29,7 +29,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`party_supplementary_data` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/P058-ColumnCardinalityTest-validity_start_time_transaction.sql
+++ b/generated_sql/spark-sql/P058-ColumnCardinalityTest-validity_start_time_transaction.sql
@@ -32,7 +32,11 @@ FROM (
             *
           FROM `PLACEHOLDER`.`transaction` AS `t0`
           WHERE
-            `t0`.`is_entity_deleted` IN (FALSE, NULL)
+            NOT (
+              `t0`.`is_entity_deleted`
+            ) OR (
+              `t0`.`is_entity_deleted` IS NULL
+            )
         ) AS `t1`
       ) AS `t2`
       WHERE

--- a/generated_sql/spark-sql/RI011-TemporalReferentialIntegrityTest_transaction.sql
+++ b/generated_sql/spark-sql/RI011-TemporalReferentialIntegrityTest_transaction.sql
@@ -27,7 +27,11 @@ WITH `table` AS (
           *
         FROM `PLACEHOLDER`.`transaction` AS `t0`
         WHERE
-          `t0`.`is_entity_deleted` IN (FALSE, NULL)
+          NOT (
+            `t0`.`is_entity_deleted`
+          ) OR (
+            `t0`.`is_entity_deleted` IS NULL
+          )
       ) AS `t2`
     ) AS `t4`
     WHERE

--- a/generated_sql/spark-sql/V017-ColumnCardinalityTest-normalized_booked_amount.currency_code_transaction.sql
+++ b/generated_sql/spark-sql/V017-ColumnCardinalityTest-normalized_booked_amount.currency_code_transaction.sql
@@ -22,7 +22,11 @@ WITH `t3` AS (
         *
       FROM `PLACEHOLDER`.`transaction` AS `t0`
       WHERE
-        `t0`.`is_entity_deleted` IN (FALSE, NULL)
+        NOT (
+          `t0`.`is_entity_deleted`
+        ) OR (
+          `t0`.`is_entity_deleted` IS NULL
+        )
     ) AS `t1`
   ) AS `t2`
   WHERE

--- a/src/amlaidatatests/base.py
+++ b/src/amlaidatatests/base.py
@@ -356,7 +356,7 @@ class AbstractTableTest(AbstractBaseTest):
             raise ValueError(f"{table_config.table_type} is not a valid table type")
         table = table.filter(
             ibis.or_(
-                _["is_entity_deleted"] == ibis.literal(False),
+                _["is_entity_deleted"].notany(),
                 _["is_entity_deleted"].isnull(),
             )
         )

--- a/src/amlaidatatests/base.py
+++ b/src/amlaidatatests/base.py
@@ -354,7 +354,12 @@ class AbstractTableTest(AbstractBaseTest):
             TableType.OPEN_ENDED_ENTITY,
         ):
             raise ValueError(f"{table_config.table_type} is not a valid table type")
-        table = table.filter(_["is_entity_deleted"].isin([ibis.literal(False), None]))
+        table = table.filter(
+            ibis.or_(
+                _["is_entity_deleted"] == ibis.literal(False),
+                _["is_entity_deleted"].isnull(),
+            )
+        )
         return table.select(
             s.all(),
             row_num=ibis.row_number().over(

--- a/src/amlaidatatests/base.py
+++ b/src/amlaidatatests/base.py
@@ -356,7 +356,7 @@ class AbstractTableTest(AbstractBaseTest):
             raise ValueError(f"{table_config.table_type} is not a valid table type")
         table = table.filter(
             ibis.or_(
-                _["is_entity_deleted"].notany(),
+                ~_["is_entity_deleted"],
                 _["is_entity_deleted"].isnull(),
             )
         )


### PR DESCRIPTION
closes #70 

Replaces filter form `field IN (False, NULL)` with `NOT(field) OR field IS NULL`

Queries written in Python ORMs e.g. 
```python
field.isin([<li>, <li>, ... None])
``` 
are compiled to SQL as 
```sql
field IN (<li>, <li>, ... NULL)
```
However, these expressions are not equivalent because `field == None` is a valid Python expression, but `field = NULL` is not valid SQL. `None in [<li>, <li>, ... None]` returns True Python, whereas `NULL IN (<li>, <li>, ... NULL)` returns NULL in SQL.