### PR TITLE
fix: use defaults to fix variable value at definition

### DIFF
--- a/generated_sql/bigquery/P022-CASH-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/bigquery/P022-CASH-CountMatchingRows-type_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS `total_rows`,
-    COUNTIF(`t3`.`type` = 'CARD') AS `matching_rows`
+    COUNTIF(`t3`.`type` = 'CASH') AS `matching_rows`
   FROM (
     SELECT
       *

--- a/generated_sql/bigquery/P022-CHECK-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/bigquery/P022-CHECK-CountMatchingRows-type_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS `total_rows`,
-    COUNTIF(`t3`.`type` = 'CARD') AS `matching_rows`
+    COUNTIF(`t3`.`type` = 'CHECK') AS `matching_rows`
   FROM (
     SELECT
       *

--- a/generated_sql/bigquery/P022-WIRE-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/bigquery/P022-WIRE-CountMatchingRows-type_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS `total_rows`,
-    COUNTIF(`t3`.`type` = 'CARD') AS `matching_rows`
+    COUNTIF(`t3`.`type` = 'WIRE') AS `matching_rows`
   FROM (
     SELECT
       *

--- a/generated_sql/bigquery/P023-CREDIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/bigquery/P023-CREDIT-CountMatchingRows-direction_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS `total_rows`,
-    COUNTIF(`t3`.`direction` = 'DEBIT') AS `matching_rows`
+    COUNTIF(`t3`.`direction` = 'CREDIT') AS `matching_rows`
   FROM (
     SELECT
       *

--- a/generated_sql/duckdb/P022-CASH-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/duckdb/P022-CASH-CountMatchingRows-type_transaction.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     COUNT(*) AS "total_rows",
     COUNT(*) FILTER(WHERE
-      "t3"."type" = 'CARD') AS "matching_rows"
+      "t3"."type" = 'CASH') AS "matching_rows"
   FROM (
     SELECT
       *

--- a/generated_sql/duckdb/P022-CHECK-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/duckdb/P022-CHECK-CountMatchingRows-type_transaction.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     COUNT(*) AS "total_rows",
     COUNT(*) FILTER(WHERE
-      "t3"."type" = 'CARD') AS "matching_rows"
+      "t3"."type" = 'CHECK') AS "matching_rows"
   FROM (
     SELECT
       *

--- a/generated_sql/duckdb/P022-WIRE-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/duckdb/P022-WIRE-CountMatchingRows-type_transaction.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     COUNT(*) AS "total_rows",
     COUNT(*) FILTER(WHERE
-      "t3"."type" = 'CARD') AS "matching_rows"
+      "t3"."type" = 'WIRE') AS "matching_rows"
   FROM (
     SELECT
       *

--- a/generated_sql/duckdb/P023-CREDIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/duckdb/P023-CREDIT-CountMatchingRows-direction_transaction.sql
@@ -10,7 +10,7 @@ FROM (
   SELECT
     COUNT(*) AS "total_rows",
     COUNT(*) FILTER(WHERE
-      "t3"."direction" = 'DEBIT') AS "matching_rows"
+      "t3"."direction" = 'CREDIT') AS "matching_rows"
   FROM (
     SELECT
       *

--- a/generated_sql/snowflake/P022-CASH-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/snowflake/P022-CASH-CountMatchingRows-type_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS "total_rows",
-    COUNT_IF("t3"."type" = 'CARD') AS "matching_rows"
+    COUNT_IF("t3"."type" = 'CASH') AS "matching_rows"
   FROM (
     SELECT
       *

--- a/generated_sql/snowflake/P022-CHECK-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/snowflake/P022-CHECK-CountMatchingRows-type_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS "total_rows",
-    COUNT_IF("t3"."type" = 'CARD') AS "matching_rows"
+    COUNT_IF("t3"."type" = 'CHECK') AS "matching_rows"
   FROM (
     SELECT
       *

--- a/generated_sql/snowflake/P022-WIRE-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/snowflake/P022-WIRE-CountMatchingRows-type_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS "total_rows",
-    COUNT_IF("t3"."type" = 'CARD') AS "matching_rows"
+    COUNT_IF("t3"."type" = 'WIRE') AS "matching_rows"
   FROM (
     SELECT
       *

--- a/generated_sql/snowflake/P023-CREDIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/snowflake/P023-CREDIT-CountMatchingRows-direction_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS "total_rows",
-    COUNT_IF("t3"."direction" = 'DEBIT') AS "matching_rows"
+    COUNT_IF("t3"."direction" = 'CREDIT') AS "matching_rows"
   FROM (
     SELECT
       *

--- a/generated_sql/spark-sql/P022-CASH-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/spark-sql/P022-CASH-CountMatchingRows-type_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS `total_rows`,
-    SUM(CAST(`t3`.`type` = 'CARD' AS BIGINT)) AS `matching_rows`
+    SUM(CAST(`t3`.`type` = 'CASH' AS BIGINT)) AS `matching_rows`
   FROM (
     SELECT
       *

--- a/generated_sql/spark-sql/P022-CHECK-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/spark-sql/P022-CHECK-CountMatchingRows-type_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS `total_rows`,
-    SUM(CAST(`t3`.`type` = 'CARD' AS BIGINT)) AS `matching_rows`
+    SUM(CAST(`t3`.`type` = 'CHECK' AS BIGINT)) AS `matching_rows`
   FROM (
     SELECT
       *

--- a/generated_sql/spark-sql/P022-WIRE-CountMatchingRows-type_transaction.sql
+++ b/generated_sql/spark-sql/P022-WIRE-CountMatchingRows-type_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS `total_rows`,
-    SUM(CAST(`t3`.`type` = 'CARD' AS BIGINT)) AS `matching_rows`
+    SUM(CAST(`t3`.`type` = 'WIRE' AS BIGINT)) AS `matching_rows`
   FROM (
     SELECT
       *

--- a/generated_sql/spark-sql/P023-CREDIT-CountMatchingRows-direction_transaction.sql
+++ b/generated_sql/spark-sql/P023-CREDIT-CountMatchingRows-direction_transaction.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     COUNT(*) AS `total_rows`,
-    SUM(CAST(`t3`.`direction` = 'DEBIT' AS BIGINT)) AS `matching_rows`
+    SUM(CAST(`t3`.`direction` = 'CREDIT' AS BIGINT)) AS `matching_rows`
   FROM (
     SELECT
       *

--- a/src/amlaidatatests/tests/test_transaction_table.py
+++ b/src/amlaidatatests/tests/test_transaction_table.py
@@ -191,7 +191,7 @@ def test_date_consistency(connection, test, request):
                 column="type",
                 table_config=TABLE_CONFIG,
                 min_number=1,
-                expression=lambda t: (t["type"] == typ),
+                expression=lambda t, typ=typ: (t["type"] == typ),
                 test_id=f"P022-{typ}",
                 explanation=f"Expected at least one row with type == '{typ}'",
             )
@@ -202,7 +202,7 @@ def test_date_consistency(connection, test, request):
                 column="direction",
                 table_config=TABLE_CONFIG,
                 min_number=1,
-                expression=lambda t: t["direction"] == direction,
+                expression=lambda t, direction=direction: t["direction"] == direction,
                 test_id=f"P023-{direction}",
                 explanation=f"Expected at least one row with direction == '{direction}'",
             )


### PR DESCRIPTION
Adds `typ=type` default to lambdas to avoid lazy eval

Fixes #79