### PR TITLE
pin-dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ python_requires = >=3.10
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
 install_requires =
-    ibis-framework[bigquery]>=9.2
+    ibis-framework[bigquery]>=9.2,<10
     importlib-metadata; python_version<"3.10"
     pytest
     omegaconf


### PR DESCRIPTION
The recent upgrade to ibis 10 has broken various operations. We should pin to version 10.