### PR TITLE
Performance optimization

### DIFF
--- a/src/amlaidatatests/base.py
+++ b/src/amlaidatatests/base.py
@@ -28,6 +28,8 @@ from amlaidatatests.schema.base import ResolvedTableConfig, TableType
 
 logger = logging.getLogger(__name__)
 
+MAX_DATETIME_VALUE = datetime.datetime(9995, 1, 1, tzinfo=datetime.timezone.utc)
+
 
 def resolve_field(table: Table, column: str) -> tuple[Table, Expr]:
     # Given a path x.y.z, resolve the field object
@@ -158,6 +160,124 @@ class AbstractBaseTest(ABC):
         # raise RuntimeError("A test failed for an unknown reason")
 
 
+def get_entity_state_windows(
+    table_config: ResolvedTableConfig, key: List[str] | None = None
+) -> Table:
+    """Generate a table indicating the time periods an entity
+    was valid between.
+
+    Limitation: currently does not handle time periods between
+                time periods.
+
+    Args:
+        table_config: _description_
+        key: Optional additional keys to aggregate to which are not table keys.
+                For example, we might want to group by account_id
+                on a transaction table. Setting this value will produce a group
+                by to the transaction level.
+
+    Returns:
+        _description_
+    """
+    # For a table with flipping is_entity_deleted:
+    #
+    # | party_id | validity_start_time | is_entity_deleted |
+    # |    1     |      00:00:00       |       False       |
+    # |    1     |      00:30:00       |       False       | <--- no flip
+    # |    1     |      01:00:00       |       True        |
+    # |    1     |      02:00:00       |       False       |
+    #
+    # |party_id|window_id| window_start_time|window_end_time|is_entity_deleted
+    # |   1    |    0    |      00:00:00    |     null      |     False
+    table = table_config.table
+
+    key = [] if not key else key
+
+    # Select potentially overlapping keys between these two entity tables
+    keys = set([*key, *table_config.entity_keys])
+
+    if table_config.table_type == TableType.EVENT:
+        return table.select(first_date=_.event_time, last_date=_.event_time, *keys)
+
+    w = ibis.window(group_by=keys, order_by="validity_start_time")
+
+    # is_entity_deleted is a nullable field, so we assume if it is null, we
+    # mean False
+    cte0 = ibis.coalesce(table.is_entity_deleted, False)
+    # First, find the changes in entity_deleted switching in order to
+    # determine the rows which lead to the table switching. do this by
+    # finding the previous values of "is_entity_deleted" and determining if.
+
+    cte1 = table.select(
+        *keys,
+        "validity_start_time",
+        is_entity_deleted=cte0,
+        previous_entity_deleted=cte0.lag().over(w),
+        next_row_validity_start_time=_.validity_start_time.lead().over(w),
+        previous_row_validity_start_time=_.validity_start_time.lag().over(w),
+    )
+
+    # Handle the entity being immediately deleted by assuming it only
+    # existed for a fraction of a second. This isn't valid data, but it
+    # should be picked up by the entity mutation tests
+    cte2 = cte1.mutate(
+        previous_row_validity_start_time=ibis.ifelse(
+            (_.previous_row_validity_start_time.isnull()) & (_.is_entity_deleted),
+            _.validity_start_time,
+            _.previous_row_validity_start_time,
+        )
+    )
+
+    # Only return useful rows, not ones where the entities deletion state
+    # didn't change
+    cte3 = cte2.filter(
+        (_.previous_row_validity_start_time == ibis.literal(None))  # first row
+        | (_.next_row_validity_start_time == ibis.literal(None))  # last row
+        | (_.is_entity_deleted != _.previous_entity_deleted)  # state flips
+    ).group_by(keys)
+
+    if table_config.table_type == TableType.CLOSED_ENDED_ENTITY:
+        # For closed ended entities, e.g. parties, we need to assume the
+        # entity persists until it is deleted. This means that the maximum
+        # validity date time
+        res = (
+            cte3
+            # At the moment, we only pay attention to the first/last dates,
+            # not where there are multiple flips if the only row and the row
+            # isn't yet deleted, we need to make the validity end time far
+            # into the future
+            .agg(
+                # null handling not required as validity_start_time is a
+                # non-nullable field
+                first_date=_.validity_start_time.min(),
+                last_date=ibis.ifelse(
+                    condition=_.next_row_validity_start_time.isnull()
+                    & ~_.is_entity_deleted,
+                    true_expr=MAX_DATETIME_VALUE,
+                    false_expr=_.validity_start_time,
+                ).max(),
+            )
+        )
+    else:
+        # The entity's validity is counted only as of the last datetime provided
+        res = (
+            cte3
+            # At the moment, we only pay attention to the first/last dates,
+            # not where there are multiple flips
+            .agg(
+                first_date=_.validity_start_time.min(),
+                last_date=_.validity_start_time.max(),
+            )
+        )
+    # There may be multiple group_by keys, which doesn't correspond
+    # to the referential integrity test testing a single key. This is because
+    # we need to handle the case where there are multiple entity keys,
+    # e.g. a party_link table where we are validating the account_id
+    return res.group_by(key if key else keys).agg(
+        first_date=_.first_date.min(), last_date=_.last_date.max()
+    )
+
+
 class AbstractTableTest(AbstractBaseTest):
     """Base class for test which are across an entire table
     and do not specify a single column
@@ -169,8 +289,6 @@ class AbstractTableTest(AbstractBaseTest):
         test_id:  A unique identifier for the test. Useful when used via
                   @pytest.parameter as it allows us to uniquely identify the test
     """
-
-    MAX_DATETIME_VALUE = datetime.datetime(9995, 1, 1, tzinfo=datetime.timezone.utc)
 
     def __init__(
         self,
@@ -186,119 +304,7 @@ class AbstractTableTest(AbstractBaseTest):
     def get_entity_state_windows(
         self, table_config: ResolvedTableConfig, key: List[str] | None = None
     ):
-        """Generate a table indicating the time periods an entity
-        was valid between.
-
-        Limitation: currently does not handle time periods between
-                    time periods.
-
-        Args:
-            table_config: _description_
-            key: Optional additional keys to aggregate to which are not table keys.
-                    For example, we might want to group by account_id
-                    on a transaction table. Setting this value will produce a group
-                    by to the transaction level.
-
-        Returns:
-            _description_
-        """
-        # For a table with flipping is_entity_deleted:
-        #
-        # | party_id | validity_start_time | is_entity_deleted |
-        # |    1     |      00:00:00       |       False       |
-        # |    1     |      00:30:00       |       False       | <--- no flip
-        # |    1     |      01:00:00       |       True        |
-        # |    1     |      02:00:00       |       False       |
-        #
-        # |party_id|window_id| window_start_time|window_end_time|is_entity_deleted
-        # |   1    |    0    |      00:00:00    |     null      |     False
-        table = table_config.table
-
-        key = [] if not key else key
-
-        # Select potentially overlapping keys between these two entity tables
-        keys = set([*key, *table_config.entity_keys])
-
-        if table_config.table_type == TableType.EVENT:
-            return table.select(first_date=_.event_time, last_date=_.event_time, *keys)
-
-        w = ibis.window(group_by=keys, order_by="validity_start_time")
-
-        # is_entity_deleted is a nullable field, so we assume if it is null, we
-        # mean False
-        cte0 = ibis.coalesce(table.is_entity_deleted, False)
-        # First, find the changes in entity_deleted switching in order to
-        # determine the rows which lead to the table switching. do this by
-        # finding the previous values of "is_entity_deleted" and determining if.
-
-        cte1 = table.select(
-            *keys,
-            "validity_start_time",
-            is_entity_deleted=cte0,
-            previous_entity_deleted=cte0.lag().over(w),
-            next_row_validity_start_time=_.validity_start_time.lead().over(w),
-            previous_row_validity_start_time=_.validity_start_time.lag().over(w),
-        )
-
-        # Handle the entity being immediately deleted by assuming it only
-        # existed for a fraction of a second. This isn't valid data, but it
-        # should be picked up by the entity mutation tests
-        cte2 = cte1.mutate(
-            previous_row_validity_start_time=ibis.ifelse(
-                (_.previous_row_validity_start_time.isnull()) & (_.is_entity_deleted),
-                _.validity_start_time,
-                _.previous_row_validity_start_time,
-            )
-        )
-
-        # Only return useful rows, not ones where the entities deletion state
-        # didn't change
-        cte3 = cte2.filter(
-            (_.previous_row_validity_start_time == ibis.literal(None))  # first row
-            | (_.next_row_validity_start_time == ibis.literal(None))  # last row
-            | (_.is_entity_deleted != _.previous_entity_deleted)  # state flips
-        ).group_by(keys)
-
-        if table_config.table_type == TableType.CLOSED_ENDED_ENTITY:
-            # For closed ended entities, e.g. parties, we need to assume the
-            # entity persists until it is deleted. This means that the maximum
-            # validity date time
-            res = (
-                cte3
-                # At the moment, we only pay attention to the first/last dates,
-                # not where there are multiple flips if the only row and the row
-                # isn't yet deleted, we need to make the validity end time far
-                # into the future
-                .agg(
-                    # null handling not required as validity_start_time is a
-                    # non-nullable field
-                    first_date=_.validity_start_time.min(),
-                    last_date=ibis.ifelse(
-                        condition=_.next_row_validity_start_time.isnull()
-                        & ~_.is_entity_deleted,
-                        true_expr=self.MAX_DATETIME_VALUE,
-                        false_expr=_.validity_start_time,
-                    ).max(),
-                )
-            )
-        else:
-            # The entity's validity is counted only as of the last datetime provided
-            res = (
-                cte3
-                # At the moment, we only pay attention to the first/last dates,
-                # not where there are multiple flips
-                .agg(
-                    first_date=_.validity_start_time.min(),
-                    last_date=_.validity_start_time.max(),
-                )
-            )
-        # There may be multiple group_by keys, which doesn't correspond
-        # to the referential integrity test testing a single key. This is because
-        # we need to handle the case where there are multiple entity keys,
-        # e.g. a party_link table where we are validating the account_id
-        return res.group_by(key if key else keys).agg(
-            first_date=_.first_date.min(), last_date=_.last_date.max()
-        )
+        return get_entity_state_windows(table_config, key)
 
     def get_table(
         self,

--- a/src/amlaidatatests/tests/common.py
+++ b/src/amlaidatatests/tests/common.py
@@ -1277,6 +1277,7 @@ class TemporalReferentialIntegrityTest(AbstractTableTest):
         table_config: ResolvedTableConfig,
         to_table_config: ResolvedTableConfig,
         key: str,
+        entity_state_table: Optional[Table] = None,
         validate_datetime_column: Optional[str] = None,
         # BQ doesn't support values longer than a day
         tolerance: Optional[
@@ -1296,6 +1297,7 @@ class TemporalReferentialIntegrityTest(AbstractTableTest):
 
         super().__init__(table_config=table_config, severity=severity, test_id=test_id)
         self.to_table = to_table_config.table
+        self.entity_state_table = entity_state_table
         self.validate_datetime_column = validate_datetime_column
         self.to_table_config = to_table_config
         self.tolerance = tolerance
@@ -1324,6 +1326,8 @@ class TemporalReferentialIntegrityTest(AbstractTableTest):
                 first_date=_[self.validate_datetime_column].min(),
                 last_date=_[self.validate_datetime_column].max(),
             )
+        elif self.entity_state_table is not None:
+            tbl = self.entity_state_table
         else:
             tbl = self.get_entity_state_windows(
                 table_config=self.table_config, key=[self.key]


### PR DESCRIPTION
Use a temporary table to save an intermediate result for the BigQuery backend to address #74:
- Move `get_entity_state_windows` out of `AbstractTableTest` so that the function can be called in a fixture
- Provide entity state windows table as an argument in `TemporalReferentialIntegrityTest`
- Save the results of `get_entity_state_windows` in a temporary table (BigQuery) and return the table in a fixture

Temporary tables are supported for BQ, DuckDB, and Snowflake backends but not for spark