### PR TITLE
Update timestamp objects with timezone

### DIFF
--- a/src/amlaidatatests/schema/v1/account_party_link.py
+++ b/src/amlaidatatests/schema/v1/account_party_link.py
@@ -27,7 +27,7 @@ account_party_link_schema = ibis.Schema(
     fields={
         "account_id": String(nullable=False),
         "party_id": String(nullable=False),
-        "validity_start_time": Timestamp(nullable=False),
+        "validity_start_time": Timestamp(nullable=False, timezone="UTC"),
         "is_entity_deleted": Boolean(),
         "role": String(),
         "source_system": String(),

--- a/src/amlaidatatests/schema/v1/party.py
+++ b/src/amlaidatatests/schema/v1/party.py
@@ -25,7 +25,7 @@ from amlaidatatests.schema.v1.common import CurrencyValue
 party_schema = ibis.Schema(
     fields={
         "party_id": String(nullable=False),
-        "validity_start_time": Timestamp(nullable=False),
+        "validity_start_time": Timestamp(nullable=False, timezone="UTC"),
         "is_entity_deleted": Boolean(),
         "source_system": String(),
         "type": String(nullable=False),

--- a/src/amlaidatatests/schema/v1/party_supplementary_data.py
+++ b/src/amlaidatatests/schema/v1/party_supplementary_data.py
@@ -24,7 +24,7 @@ from ibis.expr.datatypes import Boolean, Float64, String, Struct, Timestamp
 party_supplementary_data_schema = ibis.Schema(
     fields={
         "party_supplementary_data_id": String(nullable=False),
-        "validity_start_time": Timestamp(nullable=False),
+        "validity_start_time": Timestamp(nullable=False, timezone="UTC"),
         "is_entity_deleted": Boolean(),
         "source_system": String(),
         "party_id": String(nullable=False),

--- a/src/amlaidatatests/schema/v1/risk_case_event.py
+++ b/src/amlaidatatests/schema/v1/risk_case_event.py
@@ -12,7 +12,7 @@ from ibis.expr.datatypes import String, Timestamp
 risk_case_event_schema = schema(
     {
         "risk_case_event_id": String(nullable=False),
-        "event_time": Timestamp(nullable=False),
+        "event_time": Timestamp(nullable=False, timezone="UTC"),
         "type": String(nullable=False),
         "party_id": String(nullable=False),
         "risk_case_id": String(nullable=False),

--- a/src/amlaidatatests/schema/v1/transaction.py
+++ b/src/amlaidatatests/schema/v1/transaction.py
@@ -1,14 +1,14 @@
 """Configuration file specifying the schema for the transaction table"""
 
 import ibis
-from ibis.expr.datatypes import Boolean, String, Struct, Timestamp
+from ibis.expr.datatypes import Boolean, Int64, String, Struct, Timestamp
 
 from amlaidatatests.schema.v1.common import CurrencyValue
 
 transaction_schema = ibis.Schema(
     fields={
         "transaction_id": String(nullable=False),
-        "validity_start_time": Timestamp(nullable=False),
+        "validity_start_time": Timestamp(nullable=False, timezone="UTC"),
         "is_entity_deleted": Boolean(),
         "source_system": String(),
         "type": String(nullable=False),
@@ -20,7 +20,7 @@ transaction_schema = ibis.Schema(
                 "region_code": String(nullable=True),
             }
         ),
-        "book_time": Timestamp(),
+        "book_time": Timestamp(timezone="UTC"),
         "normalized_booked_amount": CurrencyValue(),
     }
 )


### PR DESCRIPTION
Ibis timestamps without an explicit timezone are mapped over as datetimes into bigquery unless they have a UTC timezone, which is the only valid timezone for a bigquery timestamp.

This fix adds an explicit timezone to the timestamp types so if they are used to create bigquery tables they create bigquery timestamps, not datetimes.